### PR TITLE
Upload close file when all handlers done with it

### DIFF
--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -87,6 +87,17 @@ class Upload(LabelElement, DisableableElement, component='upload.js'):
 
         This method is primarily intended for internal use and for simulating file uploads in tests.
         """
+        pending_handlers = {upload: len(self._upload_handlers) +
+                            (1 if self._multi_upload_handlers else 0) for upload in uploads}
+
+        def handler_done(upload: UploadFile):
+            pending_handlers[upload] -= 1
+            if pending_handlers[upload] == 0:
+                try:
+                    upload.file.close()
+                except Exception:
+                    pass
+
         for upload in uploads:
             for upload_handler in self._upload_handlers:
                 handle_event(upload_handler, UploadEventArguments(
@@ -95,7 +106,7 @@ class Upload(LabelElement, DisableableElement, component='upload.js'):
                     content=upload.file,
                     name=upload.filename or '',
                     type=upload.content_type or '',
-                ))
+                ), cleanup=lambda upload=upload: handler_done(upload))
         multi_upload_args = MultiUploadEventArguments(
             sender=self,
             client=self.client,
@@ -104,7 +115,8 @@ class Upload(LabelElement, DisableableElement, component='upload.js'):
             types=[upload.content_type or '' for upload in uploads],
         )
         for multi_upload_handler in self._multi_upload_handlers:
-            handle_event(multi_upload_handler, multi_upload_args)
+            handle_event(multi_upload_handler, multi_upload_args,
+                         cleanup=lambda: [handler_done(upload) for upload in uploads])
 
     def on_begin_upload(self, callback: Handler[UiEventArguments]) -> Self:
         """Add a callback to be invoked when the upload begins."""

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -403,18 +403,26 @@ EventT = TypeVar('EventT', bound=EventArguments)
 Handler = Union[Callable[[EventT], Any], Callable[[], Any]]
 
 
-def handle_event(handler: Handler[EventT] | None, arguments: EventT) -> None:
+def handle_event(
+    handler: Handler[EventT] | None,
+    arguments: EventT,
+    cleanup: Callable[[], None] | None = None
+) -> None:
     """Call the given event handler.
 
     The handler is called within the context of the parent slot of the sender.
     If the handler is a coroutine, it is scheduled as a background task.
     If the handler expects arguments, the arguments are passed to the handler.
     Exceptions are caught and handled globally.
+    Optionally, a cleanup handler can be called after the event handler.
 
     :param handler: the event handler
     :param arguments: the event arguments
+    :param cleanup: optional cleanup handler (synchronous)
     """
     if handler is None:
+        if cleanup:
+            cleanup()
         return
     try:
         parent_slot: Slot | nullcontext
@@ -442,3 +450,6 @@ def handle_event(handler: Handler[EventT] | None, arguments: EventT) -> None:
                 core.app.on_startup(wait_for_result())
     except Exception as e:
         core.app.handle_exception(e)
+    finally:
+        if cleanup:
+            cleanup()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -9,10 +9,11 @@ test_path2 = Path('tests/test_scene.py').resolve()
 
 def test_uploading_text_file(screen: Screen):
     results: list[events.UploadEventArguments] = []
+    results_bytes: list[bytes] = []
 
     @ui.page('/')
     def page():
-        ui.upload(on_upload=results.append, label='Test Title')
+        ui.upload(on_upload=lambda e: results.append(e) or results_bytes.append(e.content.read()), label='Test Title')
 
     screen.open('/')
     screen.should_contain('Test Title')
@@ -23,7 +24,7 @@ def test_uploading_text_file(screen: Screen):
     assert len(results) == 1
     assert results[0].name == test_path1.name
     assert results[0].type in {'text/x-python', 'text/x-python-script'}
-    assert results[0].content.read() == test_path1.read_bytes()
+    assert results_bytes[0] == test_path1.read_bytes()
 
 
 def test_two_upload_elements(screen: Screen):
@@ -107,10 +108,12 @@ def test_reset_upload(screen: Screen):
 
 def test_multi_upload_event(screen: Screen):
     results: list[events.MultiUploadEventArguments] = []
+    results_bytes: list[bytes] = []
 
     @ui.page('/')
     def page():
-        ui.upload(on_multi_upload=results.append, multiple=True)
+        ui.upload(on_multi_upload=lambda e: results.append(e) or results_bytes.extend(
+            [content.read() for content in e.contents]), multiple=True)
 
     screen.open('/')
     screen.find_by_class('q-uploader__input').send_keys(f'{test_path1}\n{test_path2}')
@@ -120,5 +123,4 @@ def test_multi_upload_event(screen: Screen):
 
     assert len(results) == 1
     assert results[0].names == [test_path1.name, test_path2.name]
-    assert results[0].contents[0].read() == test_path1.read_bytes()
-    assert results[0].contents[1].read() == test_path2.read_bytes()
+    assert results_bytes == [test_path1.read_bytes(), test_path2.read_bytes()]


### PR DESCRIPTION
### Motivation

This is based on #5153 and the goal is to get rid of all the UI upload errors. 

### Implementation

Now, the file will be closed once all handlers are done with it. Do not try and access the `e.content` outside of the handler anymore, it will `I/O operation on closed file` error. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [ ] Documentation has been added (or is not necessary).
  - Boy do we need to document this, this is a breaking change!
