### PR TITLE
Improve xterm example: configurable command, PTY resize, viewport sizing, lifecycle hardening

### DIFF
--- a/examples/xterm/main.py
+++ b/examples/xterm/main.py
@@ -1,27 +1,64 @@
 #!/usr/bin/env python3
-"""Example for connecting a `Xterm` element with a `Bash` process running in a pty.
+"""Example for connecting a `Xterm` element with a process running in a pty.
 
-WARNING: This example gives the clients full access to the server through Bash. Use with caution!
+Pass a command (and its arguments) to run something other than bash, e.g.::
+
+    python main.py htop
+    python main.py ipython
+    python main.py nano /tmp/notes.md
+
+WARNING: This example gives the clients full access to the server through a shell process. Use with caution!
 """
 import fcntl
 import os
 import pty
 import signal
 import struct
+import sys
 import termios
 from functools import partial
 
 from nicegui import core, events, ui
 
+command = sys.argv[1:] if len(sys.argv) > 1 else ['/bin/bash']
+
 
 @ui.page('/')
-def _page():
-    terminal = ui.xterm().classes('w-full')
+async def _page():
+    ui.query('.nicegui-content').classes('p-0')  # remove padding so the terminal can fill the viewport
+    terminal = ui.xterm().classes('w-screen h-screen')
     ui.element('q-resize-observer').on('resize', terminal.fit)
 
+    pty_pid = 0
+    pty_fd = -1
+
+    @terminal.on_data
+    def terminal_to_pty(event: events.XtermDataEventArguments):
+        try:
+            os.write(pty_fd, event.data.encode('utf-8'))
+        except OSError:
+            pass  # error writing to the pty; probably the process was exited
+
+    @terminal.on_resize
+    def resize_terminal(event: events.XtermResizeEventArguments):
+        if pty_fd < 0:
+            return
+        fcntl.ioctl(pty_fd, termios.TIOCSWINSZ, struct.pack('HHHH', event.rows, event.cols, 0, 0))
+
+    @ui.context.client.on_delete
+    def kill_process():
+        if pty_fd >= 0:
+            core.loop.remove_reader(pty_fd)  # unregister before closing so a reused FD can't trip the stale callback
+            os.close(pty_fd)
+            os.kill(pty_pid, signal.SIGKILL)
+            print('Terminal closed')
+
+    await ui.context.client.connected()
     pty_pid, pty_fd = pty.fork()  # create a new pseudo-terminal (pty) fork of the process
     if pty_pid == pty.CHILD:
-        os.execv('/bin/bash', ('bash',))  # child process of the fork gets replaced with "bash"
+        os.environ['TERM'] = 'xterm-256color'
+        os.environ['COLORTERM'] = 'truecolor'
+        os.execvp(command[0], command)  # replace the child process with the requested command
     print('Terminal opened')
 
     @partial(core.loop.add_reader, pty_fd)
@@ -29,28 +66,13 @@ def _page():
         try:
             data = os.read(pty_fd, 1024)
         except OSError:
-            print('Stopping reading from pty')  # error reading the pty; probably bash was exited
+            data = b''  # error reading the pty; probably the process was exited
+        if not data:  # EOF on some platforms arrives as an empty read, not an OSError
+            print('Stopping reading from pty')
             core.loop.remove_reader(pty_fd)
-        else:
+            return
+        if not terminal.is_deleted:
             terminal.write(data)
-
-    @terminal.on_data
-    def terminal_to_pty(event: events.XtermDataEventArguments):
-        try:
-            os.write(pty_fd, event.data.encode('utf-8'))
-        except OSError:
-            pass  # error writing to the pty; probably bash was exited
-
-    @terminal.on_resize
-    def resize_terminal(event: events.XtermResizeEventArguments):
-        fcntl.ioctl(pty_fd, termios.TIOCSWINSZ, struct.pack('HHHH', event.rows, event.cols, 0, 0))
-        print(f'Terminal resized to {event.cols}x{event.rows}')
-
-    @ui.context.client.on_delete
-    def kill_bash():
-        os.close(pty_fd)
-        os.kill(pty_pid, signal.SIGKILL)
-        print('Terminal closed')
 
 
 ui.run()


### PR DESCRIPTION
### Motivation

The `examples/xterm` demo was bash-only with a startup race: the PTY forked before the browser connected, dropping the first burst of output; `on_delete` also did not guard against a PTY that had never been opened.

### Implementation

Single-file change to `examples/xterm/main.py`:

- **Configurable command** — `sys.argv[1:]` (default `['/bin/bash']`), exec'd with `os.execvp(command[0], command)` (argv list, no shell).
- **Startup race fix** — `await ui.context.client.connected()` before `pty.fork()`.
- **Teardown hardening** — `on_delete` guards with `pty_fd >= 0` and calls `core.loop.remove_reader(pty_fd)` before `os.close`; `pty_to_terminal` also handles the empty-read EOF case so a silent EOF does not spin the event loop.
- **Resize** — keeps the typed `terminal.on_resize` handler from #5858 with a `pty_fd < 0` early-return for pre-fork events, and drops the noisy `Terminal resized to …` print.
- **Viewport sizing** — `.nicegui-content { padding: 0 }` + `w-screen h-screen` so TUIs fill the window instead of a tiny strip.
- **Child environment** — `TERM=xterm-256color` + `COLORTERM=truecolor` so `nano` / `htop` render in full color.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary — `examples/*` is not covered by the test suite.
- [x] Documentation is not necessary — the example's module docstring is self-documenting.
- [x] No breaking changes to the public API.