### PR TITLE
Randomize test ports/dirs for parallel pytest sessions

### DIFF
--- a/nicegui/testing/general.py
+++ b/nicegui/testing/general.py
@@ -7,6 +7,7 @@ from starlette.routing import Route
 
 from .. import app, binding, core, dependencies, event, run, ui
 from ..client import Client
+from ..storage import Storage
 
 
 def prepare_simulation() -> None:
@@ -56,6 +57,7 @@ def nicegui_reset_globals():
     Client.shared_head_html = ''
     Client.shared_body_html = ''
     app.reset()
+    app.storage = Storage()
     binding.reset()
 
     gc.collect()
@@ -66,6 +68,7 @@ def nicegui_reset_globals():
         gc.collect()
 
         app.reset()
+        app.storage = Storage()
         event.reset()
         run.reset()
 

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -1,8 +1,16 @@
+import os
+import shutil
+import tempfile
 from pathlib import Path
 
 import pytest
 
-from . import general
+# Set up session-unique storage directory BEFORE importing nicegui modules.
+# This ensures Storage.path reads the correct env var during class definition.
+_nicegui_storage_dir = tempfile.mkdtemp(prefix='nicegui-test-storage-')
+os.environ['NICEGUI_STORAGE_PATH'] = _nicegui_storage_dir
+
+from . import general  # noqa: E402  # pylint: disable=wrong-import-position  # must be after env var setup
 
 # pylint: disable=redefined-outer-name
 
@@ -13,8 +21,19 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Register the "nicegui_main_file" marker."""
+    """Register the "nicegui_main_file" marker and set up session-unique storage path."""
     config.addinivalue_line('markers', 'nicegui_main_file: specify the main file for the test')
+
+    # Also update Storage.path directly in case the class was already imported
+    # before the env var was set (nicegui/__init__.py imports storage early).
+    from ..storage import Storage  # pylint: disable=import-outside-toplevel
+    Storage.path = Path(_nicegui_storage_dir).resolve()
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:  # pylint: disable=unused-argument
+    """Clean up session-unique storage directory."""
+    if _nicegui_storage_dir:
+        shutil.rmtree(_nicegui_storage_dir, ignore_errors=True)
 
 
 def get_path_to_main_file(request: pytest.FixtureRequest) -> Path | None:

--- a/nicegui/testing/plugin.py
+++ b/nicegui/testing/plugin.py
@@ -1,5 +1,10 @@
 # pylint: disable=unused-import
-from .general_fixtures import nicegui_reset_globals, pytest_addoption, pytest_configure  # noqa: F401
+from .general_fixtures import (  # noqa: F401
+    nicegui_reset_globals,
+    pytest_addoption,
+    pytest_configure,
+    pytest_unconfigure,
+)
 from .screen_plugin import (  # noqa: F401
     nicegui_chrome_options,
     nicegui_driver,

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+import socket
+import tempfile
 from collections.abc import Generator
 from pathlib import Path
 
@@ -11,12 +13,23 @@ from .general_fixtures import (  # noqa: F401  # pylint: disable=unused-import
     nicegui_reset_globals,
     pytest_addoption,
     pytest_configure,
+    pytest_unconfigure,
 )
 from .screen import Screen
 
 # pylint: disable=redefined-outer-name
 
-DOWNLOAD_DIR = Path(__file__).parent / 'download'
+
+def _find_free_port() -> int:
+    """Find a free port usable by ui.run (which binds to all interfaces by default)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('0.0.0.0', 0))
+        return s.getsockname()[1]
+
+
+Screen.PORT = _find_free_port()
+Screen.SCREENSHOT_DIR = Path('screenshots') / str(os.getpid())
+DOWNLOAD_DIR = Path(tempfile.mkdtemp(prefix='nicegui-test-download-'))
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/nicegui/testing/user_plugin.py
+++ b/nicegui/testing/user_plugin.py
@@ -12,6 +12,7 @@ from .general_fixtures import (  # noqa: F401  # pylint: disable=unused-import
     get_path_to_main_file,
     pytest_addoption,
     pytest_configure,
+    pytest_unconfigure,
 )
 from .user import User
 from .user_simulation import prepare_simulation, user_simulation

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,13 +1,13 @@
 import asyncio
 import copy
 import time
-from pathlib import Path
 
 import httpx
 import pytest
 
 from nicegui import Client, app, background_tasks, context, core, nicegui, ui
 from nicegui.persistence.file_persistent_dict import FilePersistentDict
+from nicegui.storage import Storage
 from nicegui.testing import Screen, User
 
 
@@ -97,7 +97,7 @@ def test_access_user_storage_from_fastapi(screen: Screen):
         assert response.status_code == 200
         assert response.text == '"OK"'
         time.sleep(0.5)  # wait for storage to be written
-        assert next(Path('.nicegui').glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"msg":"yes"}'
+        assert next(Storage.path.glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"msg":"yes"}'
 
 
 def test_access_user_storage_on_interaction(screen: Screen):
@@ -111,7 +111,7 @@ def test_access_user_storage_on_interaction(screen: Screen):
     screen.open('/')
     screen.click('switch')
     screen.wait(0.5)
-    assert next(Path('.nicegui').glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"test_switch":true}'
+    assert next(Storage.path.glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"test_switch":true}'
 
 
 def test_access_user_storage_from_button_click_handler(screen: Screen):
@@ -124,7 +124,7 @@ def test_access_user_storage_from_button_click_handler(screen: Screen):
     screen.click('test')
     screen.wait(1)
     assert \
-        next(Path('.nicegui').glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"inner_function":"works"}'
+        next(Storage.path.glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"inner_function":"works"}'
 
 
 def test_access_user_storage_from_background_task(screen: Screen):
@@ -141,7 +141,7 @@ def test_access_user_storage_from_background_task(screen: Screen):
     screen.ui_run_kwargs['storage_secret'] = 'just a test'
     screen.open('/')
     screen.should_contain('Done')
-    assert next(Path('.nicegui').glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"subtask":"works"}'
+    assert next(Storage.path.glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"subtask":"works"}'
 
 
 def test_user_and_general_storage_is_persisted(screen: Screen):
@@ -177,7 +177,7 @@ def test_rapid_storage(screen: Screen):
     screen.open('/')
     screen.click('test')
     screen.wait(0.5)
-    assert Path('.nicegui', 'storage-general.json').read_text(encoding='utf-8') == '{"one":1,"two":2,"three":3}'
+    assert (Storage.path / 'storage-general.json').read_text(encoding='utf-8') == '{"one":1,"two":2,"three":3}'
 
 
 def test_tab_storage_is_local(screen: Screen):
@@ -282,7 +282,7 @@ def test_deepcopy(screen: Screen):
     screen.open('/')
     screen.should_contain('Loaded')
     screen.wait(0.5)
-    assert Path('.nicegui', 'storage-general.json').read_text(encoding='utf-8') == '{"a":{"b":0}}'
+    assert (Storage.path / 'storage-general.json').read_text(encoding='utf-8') == '{"a":{"b":0}}'
 
 
 def test_missing_storage_secret(screen: Screen):
@@ -361,7 +361,7 @@ async def test_user_storage_is_pruned(screen: Screen):
     assert len(Client.instances) == 1
     assert len(app.storage._users) == 1
 
-    response = httpx.get('http://localhost:3392/status')
+    response = httpx.get(f'http://localhost:{Screen.PORT}/status')
     assert response.status_code == 200
     assert response.text == '"ok"'
     assert len(Client.instances) == 1

--- a/website/documentation/content/screen_documentation.py
+++ b/website/documentation/content/screen_documentation.py
@@ -32,9 +32,9 @@ def screen_fixture():
 doc.text('Configuration', '''
     The `screen` fixture can be configured by setting the following static attributes:
 
-    - `PORT`: The port to use for the server (default: 3392).
+    - `PORT`: The port to use for the server (default: automatically determined free port).
     - `IMPLICIT_WAIT`: The implicit wait time in seconds (default: 4).
-    - `SCREENSHOT_DIR`: The directory to store the screenshots (default: "screenshots").
+    - `SCREENSHOT_DIR`: The directory to store the screenshots (default: `screenshots/<pid>`, a per-process subdirectory so parallel `pytest` invocations do not collide).
     - `CATCH_JS_ERRORS`: Whether to catch JavaScript errors (default: `True`, *added in version 3.2.0*).
 ''')
 


### PR DESCRIPTION
### Motivation

Two `pytest` invocations cannot run simultaneously today: `Screen.PORT` is hardcoded to `3392`, `Screen.SCREENSHOT_DIR` is a fixed `'screenshots'`, and NiceGUI's file-based storage resolves to a fixed `.nicegui/` dir. Running a second process collides on port bind, on screenshot filenames, and on persistent storage files. This PR makes those session-unique so two (or more) pytest runs can share a working directory without stomping each other.

### Implementation

- **`nicegui/testing/screen_plugin.py`**
  - New `_find_free_port()` binds an ephemeral `AF_INET / SOCK_STREAM` to `('0.0.0.0', 0)`. It binds on `0.0.0.0` deliberately — `ui.run` defaults to binding on all interfaces, so probing the same namespace avoids a port-free-on-loopback-but-busy-on-another-interface race.
  - `Screen.PORT` is set to that free port, `Screen.SCREENSHOT_DIR` to `Path('screenshots') / str(os.getpid())`, and `DOWNLOAD_DIR` moves from a fixed relative path to `tempfile.mkdtemp(prefix='nicegui-test-download-')`.
- **`nicegui/testing/general_fixtures.py`**
  - Creates a session-unique storage dir via `tempfile.mkdtemp(prefix='nicegui-test-storage-')` and sets `NICEGUI_STORAGE_PATH` *before* `from . import general`. This matters because `Storage.path` is a class-level attribute evaluated at class-definition time — if `nicegui.storage` is imported before the env var is set, the path would freeze to `.nicegui`.
  - `pytest_configure` also explicitly sets `Storage.path` as a belt-and-suspenders fallback (some import paths reach `nicegui.storage` before this module runs).
  - `pytest_unconfigure` removes the temp storage dir.
- **`nicegui/testing/general.py`**
  - `nicegui_reset_globals` now also does `app.storage = Storage()` on each reset. This is necessary because `Storage.__init__` captures `Storage.path` into the instance's internal `PersistentDict` at creation time — the pre-existing `app.storage` (instantiated at nicegui import, before the env var took effect) keeps a stale handle otherwise.
- **`nicegui/testing/plugin.py` / `user_plugin.py`**: re-export the new `pytest_unconfigure` hook.
- **`tests/test_storage.py`**: replace `Path('.nicegui')` literals with `Storage.path`, and the hardcoded `http://localhost:3392/status` with `http://localhost:{Screen.PORT}/status`.
- **`website/documentation/content/screen_documentation.py`**: update the `SCREENSHOT_DIR` default note to `screenshots/<pid>`.

### Empirical validation

Two parallel pytest invocations from the same worktree, both using the Screen fixture:

```
$ uv run pytest tests/test_button.py -v  # 4/4 PASSED in 4.10s
$ uv run pytest tests/test_chip.py   -v  # 2/2 PASSED in 3.99s
```

Both picked different free ports, wrote to different `screenshots/<pid>` directories, and got their own `tempfile.mkdtemp` download dirs. No `address in use`, no errors.

### Notes on observable defaults

Three observable defaults change. None are hard breaks — the idiomatic way to use each surface was always indirect — but worth calling out:

- **`Screen.PORT`** was `3392` and is now a random free port per process. Tests that hardcoded `3392` (e.g. `http://localhost:3392/...`) need to read `Screen.PORT`, which has always been the documented-public way. This PR applies that migration to NiceGUI's own `test_storage.py`.
- **`Screen.SCREENSHOT_DIR`** was `'screenshots'` and is now `'screenshots/<pid>'`. Same shape as the existing `.failed.png` convention — a subpath under the screenshots root, transparent to anyone who reads screenshots via `Screen.SCREENSHOT_DIR` rather than hardcoding the literal.
- **`Storage.path`** (when the testing plugin is loaded) now points to a session-unique tempdir instead of `.nicegui/`. Reading `.nicegui/` directly in test code was never a supported pattern — the `Storage.path` attribute is the contract. NiceGUI's own `test_storage.py` is migrated to match.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been updated (affected `tests/test_storage.py` exercises storage + port paths).
- [x] Documentation has been updated (`screen_documentation.py`).
- [x] No breaking changes to the public API — observable default values move, but the documented accessors (`Screen.PORT`, `Screen.SCREENSHOT_DIR`, `Storage.path`) are unchanged. Migration notes above.