### PR TITLE
Add shared=True parameter to @ui.page for shared page instances

### DIFF
--- a/SHARED_PAGES_GUIDERAILS.md
+++ b/SHARED_PAGES_GUIDERAILS.md
@@ -20,36 +20,43 @@ Guiderails fall into two categories:
 ## RuntimeError Guiderails
 
 ### `app.storage.tab`
+
 **File:** `nicegui/storage.py` (`.tab` property)
 
 Tab storage is keyed by individual browser tab identity. On a shared page, there is only one `Client` — the concept of "which tab" is meaningless because the server cannot distinguish between tabs belonging to different users.
 
 ### `app.storage.client`
+
 **File:** `nicegui/storage.py` (`.client` property)
 
 Client storage is per-`Client` volatile state. Since all browsers share the same `Client` on a shared page, writing to `app.storage.client` would create a shared mutable dict that all users silently read/write to — a race condition and identity confusion bug.
 
 ### `app.storage.user`
+
 **File:** `nicegui/storage.py` (`.user` property)
 
 User storage is keyed by session cookie ID from the HTTP request. On a shared page, only the most recent request is stored on the `Client`, so `app.storage.user` would return the storage of whichever user visited most recently — a data leak.
 
 ### `app.storage.browser`
+
 **File:** `nicegui/storage.py` (`.browser` property)
 
 Browser storage reads from the session cookie of the current request. Same problem as `app.storage.user`: on a shared page, the request belongs to whichever browser loaded last.
 
 ### `await client.run_javascript(...)`
+
 **File:** `nicegui/client.py` (`run_javascript` method, `send_and_wait` inner function)
 
 When `run_javascript` is awaited, the server waits for a single response. On a shared page, the JavaScript executes on **all** connected browsers, and multiple responses would race to fulfill the same future — producing undefined behavior. Fire-and-forget (`run_javascript` without `await`) is still allowed (with a warning).
 
 ### `await client.disconnected()`
+
 **File:** `nicegui/client.py` (`disconnected` method)
 
 `disconnected()` blocks until the client is deleted. Shared clients are never deleted (they persist as long as the `page` object holds a weakref to them), so this would block forever.
 
 ### `ui.sub_pages`
+
 **File:** `nicegui/elements/sub_pages.py` (`SubPages.__init__`)
 
 `ui.sub_pages` provides client-side routing within a page. Navigation events (URL changes) are dispatched to the `Client`, which on a shared page would re-route **all** connected browsers simultaneously. This is not just a broadcast problem — it would break the element tree for everyone.
@@ -59,31 +66,37 @@ When `run_javascript` is awaited, the server waits for a single response. On a s
 ## Warning Guiderails
 
 ### `ui.notify`
+
 **File:** `nicegui/functions/notify.py`
 
 Notifications are sent via the outbox to `client.id`. On a shared page, this means every connected browser sees the notification. This *may* be intentional (e.g., a system-wide alert), so it's a warning rather than an error.
 
 ### `ui.navigate.to`
+
 **File:** `nicegui/functions/navigate.py`
 
 Navigation commands are sent to all browsers in the `client.id` room. On a shared page, calling `ui.navigate.to('/other')` would redirect every visitor. Warned because there are edge cases where this is desired.
 
 ### `client.open`
+
 **File:** `nicegui/client.py` (`open` method)
 
 Same broadcast issue as `ui.navigate.to` — opens a URL on all connected browsers.
 
 ### `client.download`
+
 **File:** `nicegui/client.py` (`download` method)
 
 Triggers a file download on all connected browsers simultaneously. Warned because a developer might intentionally push a file to all viewers.
 
 ### `client.ip`
+
 **File:** `nicegui/client.py` (`ip` property)
 
 Returns the IP address from `self.request.client.host`. On a shared page, `self.request` is overwritten on each visit, so this always returns the **most recent** visitor's IP — not any specific user's IP.
 
 ### `run_javascript` (fire-and-forget)
+
 **File:** `nicegui/client.py` (`run_javascript` method)
 
 When called without `await`, the JavaScript runs on all browsers. This is warned (not blocked) because broadcasting JS to all viewers can be legitimate (e.g., triggering a visual effect).
@@ -93,11 +106,13 @@ When called without `await`, the JavaScript runs on all browsers. This is warned
 ## Lifecycle Guiderails
 
 ### Shared clients exempt from pruning
+
 **File:** `nicegui/client.py` (`prune_instances` classmethod)
 
 `Client.prune_instances()` periodically removes stale clients that never established a socket connection. Shared clients are excluded because they should persist for the lifetime of the application — they represent a long-lived page, not a per-user session.
 
 ### Shared clients exempt from disconnect deletion
+
 **File:** `nicegui/client.py` (`handle_disconnect` method)
 
 When a browser disconnects from a normal page, the client is deleted after a timeout. For shared pages, the client must survive individual browser disconnects because other browsers may still be connected (or new ones may connect later).

--- a/SHARED_PAGES_GUIDERAILS.md
+++ b/SHARED_PAGES_GUIDERAILS.md
@@ -125,6 +125,6 @@ When a browser disconnects from a normal page, the client is deleted after a tim
 
 2. **Errors for identity-dependent features**: Storage tiers (`tab`, `client`, `user`, `browser`) fundamentally depend on knowing *which* user is making the request. On a shared page this information is lost, so any use is a bug. `app.storage.general` is recommended as the alternative.
 
-3. **Weakref-based client reuse**: The shared client is held via `weakref.ref` on the `page` instance. If the client is somehow garbage-collected (all references dropped), the next visitor transparently creates a fresh one. This avoids memory leaks while keeping the shared page alive as long as it's in use.
+3. **Application-lifetime shared clients**: The `page` instance keeps a direct reference to the shared `Client`. Shared clients are also retained by the normal client registry (`Client.instances`) and are intentionally exempt from pruning and disconnect-based deletion, so they persist for the lifetime of the application. This matches the mental model of a shared page: a single long-lived instance that all visitors see, regardless of whether any browser is currently connected.
 
 4. **No auto-index re-implementation**: NiceGUI 2.x had an "auto-index" page that was implicitly shared. This was removed in 3.0 (PR #5005) because it was too complex and confusing. The new `shared=True` parameter is explicit, opt-in, and much simpler — it's just 15 lines in `page.py` plus guiderails.

--- a/SHARED_PAGES_GUIDERAILS.md
+++ b/SHARED_PAGES_GUIDERAILS.md
@@ -1,0 +1,115 @@
+# Shared Pages Guiderails
+
+This document describes the guiderails added for the `shared=True` parameter on `@ui.page()` and the reasoning behind each one.
+
+## Background
+
+When `@ui.page('/', shared=True)` is used, **all visitors share the same `Client` instance**. The page function runs only once; subsequent visitors receive the already-built HTML and join the same Socket.IO room. This means every message sent to `client.id` reaches every connected browser simultaneously.
+
+This is fundamentally different from the default per-user pages where each visitor gets their own `Client`, their own element tree, and their own communication channel.
+
+## Guiderail Categories
+
+Guiderails fall into two categories:
+
+- **`RuntimeError`** — the feature is fundamentally incompatible with shared pages and would produce incorrect or broken behavior. Using it is always a mistake.
+- **`warn_once`** — the feature *works* but broadcasts to all connected browsers, which may or may not be intentional. The warning fires once per message to avoid log spam.
+
+---
+
+## RuntimeError Guiderails
+
+### `app.storage.tab`
+**File:** `nicegui/storage.py` (`.tab` property)
+
+Tab storage is keyed by individual browser tab identity. On a shared page, there is only one `Client` — the concept of "which tab" is meaningless because the server cannot distinguish between tabs belonging to different users.
+
+### `app.storage.client`
+**File:** `nicegui/storage.py` (`.client` property)
+
+Client storage is per-`Client` volatile state. Since all browsers share the same `Client` on a shared page, writing to `app.storage.client` would create a shared mutable dict that all users silently read/write to — a race condition and identity confusion bug.
+
+### `app.storage.user`
+**File:** `nicegui/storage.py` (`.user` property)
+
+User storage is keyed by session cookie ID from the HTTP request. On a shared page, only the most recent request is stored on the `Client`, so `app.storage.user` would return the storage of whichever user visited most recently — a data leak.
+
+### `app.storage.browser`
+**File:** `nicegui/storage.py` (`.browser` property)
+
+Browser storage reads from the session cookie of the current request. Same problem as `app.storage.user`: on a shared page, the request belongs to whichever browser loaded last.
+
+### `await client.run_javascript(...)`
+**File:** `nicegui/client.py` (`run_javascript` method, `send_and_wait` inner function)
+
+When `run_javascript` is awaited, the server waits for a single response. On a shared page, the JavaScript executes on **all** connected browsers, and multiple responses would race to fulfill the same future — producing undefined behavior. Fire-and-forget (`run_javascript` without `await`) is still allowed (with a warning).
+
+### `await client.disconnected()`
+**File:** `nicegui/client.py` (`disconnected` method)
+
+`disconnected()` blocks until the client is deleted. Shared clients are never deleted (they persist as long as the `page` object holds a weakref to them), so this would block forever.
+
+### `ui.sub_pages`
+**File:** `nicegui/elements/sub_pages.py` (`SubPages.__init__`)
+
+`ui.sub_pages` provides client-side routing within a page. Navigation events (URL changes) are dispatched to the `Client`, which on a shared page would re-route **all** connected browsers simultaneously. This is not just a broadcast problem — it would break the element tree for everyone.
+
+---
+
+## Warning Guiderails
+
+### `ui.notify`
+**File:** `nicegui/functions/notify.py`
+
+Notifications are sent via the outbox to `client.id`. On a shared page, this means every connected browser sees the notification. This *may* be intentional (e.g., a system-wide alert), so it's a warning rather than an error.
+
+### `ui.navigate.to`
+**File:** `nicegui/functions/navigate.py`
+
+Navigation commands are sent to all browsers in the `client.id` room. On a shared page, calling `ui.navigate.to('/other')` would redirect every visitor. Warned because there are edge cases where this is desired.
+
+### `client.open`
+**File:** `nicegui/client.py` (`open` method)
+
+Same broadcast issue as `ui.navigate.to` — opens a URL on all connected browsers.
+
+### `client.download`
+**File:** `nicegui/client.py` (`download` method)
+
+Triggers a file download on all connected browsers simultaneously. Warned because a developer might intentionally push a file to all viewers.
+
+### `client.ip`
+**File:** `nicegui/client.py` (`ip` property)
+
+Returns the IP address from `self.request.client.host`. On a shared page, `self.request` is overwritten on each visit, so this always returns the **most recent** visitor's IP — not any specific user's IP.
+
+### `run_javascript` (fire-and-forget)
+**File:** `nicegui/client.py` (`run_javascript` method)
+
+When called without `await`, the JavaScript runs on all browsers. This is warned (not blocked) because broadcasting JS to all viewers can be legitimate (e.g., triggering a visual effect).
+
+---
+
+## Lifecycle Guiderails
+
+### Shared clients exempt from pruning
+**File:** `nicegui/client.py` (`prune_instances` classmethod)
+
+`Client.prune_instances()` periodically removes stale clients that never established a socket connection. Shared clients are excluded because they should persist for the lifetime of the application — they represent a long-lived page, not a per-user session.
+
+### Shared clients exempt from disconnect deletion
+**File:** `nicegui/client.py` (`handle_disconnect` method)
+
+When a browser disconnects from a normal page, the client is deleted after a timeout. For shared pages, the client must survive individual browser disconnects because other browsers may still be connected (or new ones may connect later).
+
+---
+
+## Design Decisions
+
+1. **Warnings over errors for broadcast behavior**: Features like `ui.notify` and `ui.navigate.to` technically *work* on shared pages — they just affect everyone. Since a developer might intentionally want this (e.g., a dashboard that navigates all viewers to an alert page), we warn rather than block.
+
+2. **Errors for identity-dependent features**: Storage tiers (`tab`, `client`, `user`, `browser`) fundamentally depend on knowing *which* user is making the request. On a shared page this information is lost, so any use is a bug. `app.storage.general` is recommended as the alternative.
+
+3. **Weakref-based client reuse**: The shared client is held via `weakref.ref` on the `page` instance. If the client is somehow garbage-collected (all references dropped), the next visitor transparently creates a fresh one. This avoids memory leaks while keeping the shared page alive as long as it's in use.
+
+4. **No auto-index re-implementation**: NiceGUI 2.x had an "auto-index" page that was implicitly shared. This was removed in 3.0 (PR #5005) because it was too complex and confusing. The new `shared=True` parameter is explicit, opt-in, and much simpler — it's just 15 lines in `page.py` plus guiderails.

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -124,7 +124,12 @@ class Client:
 
         *Updated in version 2.0.0: The IP address is available even before the client connects.*
         *Updated in version 3.0.0: The IP address is always defined (never ``None``).*
+
+        Note: On shared pages, this returns the IP of the most recent visitor, not any specific user.
         """
+        if self.is_shared:
+            helpers.warn_once('client.ip on a shared page returns the IP of the most recent visitor, '
+                              'not any specific user')
         return self.request.client.host if self.request.client is not None else ''
 
     @property
@@ -235,11 +240,16 @@ class Client:
         Internally, ``await client.connected()`` is called before the JavaScript code is executed (*since version 3.0.0*).
         This might delay the execution of the JavaScript code and is not covered by the ``timeout`` parameter.
 
+        Note: On shared pages, JavaScript is executed on **all** connected browsers.
+        Awaiting the result is not supported on shared pages because multiple browsers would respond.
+
         :param code: JavaScript code to run
         :param timeout: timeout in seconds (default: 1.0)
 
         :return: AwaitableResponse that can be awaited to get the result of the JavaScript code
         """
+        if self.is_shared:
+            helpers.warn_once('run_javascript on a shared page will execute on ALL connected browsers')
         request_id = str(uuid.uuid4())
         target_id = self._temporary_socket_id or self.id
 
@@ -247,6 +257,11 @@ class Client:
             self.outbox.enqueue_message('run_javascript', {'code': code}, target_id)
 
         async def send_and_wait():
+            if self.is_shared:
+                raise RuntimeError(
+                    'Cannot await run_javascript on a shared page because multiple browsers would respond. '
+                    'Use run_javascript without await instead (fire-and-forget).'
+                )
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             await self.connected()
             return await JavaScriptRequest(request_id, timeout=timeout)
@@ -255,11 +270,15 @@ class Client:
 
     def open(self, target: Callable | str, new_tab: bool = False) -> None:
         """Open a new page in the client."""
+        if self.is_shared:
+            helpers.warn_once('client.open on a shared page will navigate ALL connected browsers')
         path = target if isinstance(target, str) else self.page_routes[target]
         self.outbox.enqueue_message('open', {'path': path, 'new_tab': new_tab}, self.id)
 
     def download(self, src: str | bytes, filename: str | None = None, media_type: str = '') -> None:
         """Download a file from a given URL or raw bytes."""
+        if self.is_shared:
+            helpers.warn_once('client.download on a shared page will trigger download on ALL connected browsers')
         self.outbox.enqueue_message('download', {'src': src, 'filename': filename, 'media_type': media_type}, self.id)
 
     def on_connect(self, handler: Callable) -> None:
@@ -331,7 +350,8 @@ class Client:
                 self._num_connections.pop(document_id)
                 self._delete_tasks.pop(document_id)
                 await core.app.storage.close_tab(tab_id_to_close)
-                self.delete()
+                if not self.is_shared:
+                    self.delete()
         self._delete_tasks[document_id] = \
             background_tasks.create(delete_content(), name=f'delete content {document_id}')
 
@@ -426,6 +446,11 @@ class Client:
                               'See https://github.com/zauberzeug/nicegui/issues/3028 for more information.',
                               stack_info=True)
 
+    @property
+    def is_shared(self) -> bool:
+        """Whether this client belongs to a shared page."""
+        return self.page.shared
+
     @classmethod
     def prune_instances(cls, *, client_age_threshold: float = 60.0) -> None:
         """Prune stale clients."""
@@ -434,6 +459,7 @@ class Client:
                 client
                 for client in cls.instances.values()
                 if (
+                    not client.is_shared and
                     not client.has_socket_connection and
                     not client._delete_tasks and  # pylint: disable=protected-access
                     client.created <= time.time() - client_age_threshold

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -339,8 +339,14 @@ class Client:
         document_id = self._socket_to_document_id.pop(socket_id)
         self._cancel_delete_task(document_id)
         self._num_connections[document_id] -= 1
-        tab_id_to_close = self.tab_id
-        self.tab_id = None
+        # On shared pages, a single `Client.tab_id` cannot represent the many connected tabs:
+        # it is overwritten on every handshake, so closing it on disconnect would close
+        # whichever tab happened to connect most recently - possibly one still in use.
+        # Tab storage is also disallowed on shared pages (see storage.py), so there is
+        # nothing meaningful to close here.
+        tab_id_to_close = None if self.is_shared else self.tab_id
+        if not self.is_shared:
+            self.tab_id = None
 
         for t in self.disconnect_handlers:
             self.safe_invoke(t)
@@ -352,7 +358,8 @@ class Client:
             if self._num_connections[document_id] == 0:
                 self._num_connections.pop(document_id)
                 self._delete_tasks.pop(document_id)
-                await core.app.storage.close_tab(tab_id_to_close)
+                if tab_id_to_close is not None:
+                    await core.app.storage.close_tab(tab_id_to_close)
                 if not self.is_shared:
                     self.delete()
         self._delete_tasks[document_id] = \

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -223,6 +223,9 @@ class Client:
 
     async def disconnected(self) -> None:
         """Block execution until the client disconnects."""
+        if self.is_shared:
+            raise RuntimeError('client.disconnected() is not supported on shared pages because the shared client '
+                               'is never deleted; use client.on_disconnect() to handle individual browser disconnects')
         if not self.has_socket_connection:
             await self.connected()
         if self.id in self.instances:

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -39,6 +39,9 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         :param show_404: whether to show a 404 error message if the full path could not be consumed
             (can be useful for dynamically created nested sub pages) (default: ``True``)
         """
+        if context.client.is_shared:
+            raise RuntimeError('ui.sub_pages is not supported on shared pages because navigation would affect '
+                               'all connected browsers simultaneously')
         super().__init__()
         self._router = context.client.sub_pages_router
         self._routes = routes or {}

--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -66,16 +66,19 @@ class Navigate:
         else:
             raise TypeError(f'Invalid target type: {type(target)}')
 
+        client = context.client
+        if client.is_shared:
+            helpers.warn_once('ui.navigate.to on a shared page will navigate ALL connected browsers')
+
         if not new_tab and isinstance(target, str):
             parsed = urlparse(path)
             if not parsed.scheme and not parsed.netloc and \
-                    any(isinstance(el, SubPages) for el in context.client.elements.values()):
-                client = context.client
+                    any(isinstance(el, SubPages) for el in client.elements.values()):
                 navigate_coro = client.sub_pages_router._handle_navigate(path)  # pylint: disable=protected-access
                 background_tasks.create(helpers.await_with_context(navigate_coro, client), name='navigate_sub_pages')
                 return
 
-        context.client.open(path, new_tab)
+        client.open(path, new_tab)
 
 
 class History:

--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -1,5 +1,6 @@
 from typing import Any, Literal
 
+from .. import helpers
 from ..context import context
 
 ARG_MAP = {
@@ -50,4 +51,6 @@ def notify(message: Any, *,
     options['message'] = str(message)
     options.update(kwargs)
     client = context.client
+    if client.is_shared:
+        helpers.warn_once('ui.notify on a shared page will show the notification on ALL connected browsers')
     client.outbox.enqueue_message('notify', options, client.id)

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import weakref
 from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
@@ -29,6 +30,7 @@ class page:
                  favicon: str | Path | None = None,
                  dark: bool | None = ...,  # type: ignore
                  language: Language = ...,  # type: ignore
+                 shared: bool = False,
                  response_timeout: float = 3.0,
                  reconnect_timeout: float | None = None,
                  api_router: APIRouter | None = None,
@@ -37,8 +39,9 @@ class page:
         """Page
 
         This decorator marks a function to be a page builder.
-        Each user accessing the given route will see a new instance of the page.
+        By default, each user accessing the given route will see a new instance of the page.
         This means it is private to the user and not shared with others.
+        If ``shared`` is ``True``, all users will see and interact with the same page instance.
 
         Notes:
 
@@ -55,6 +58,7 @@ class page:
         :param favicon: optional relative filepath or absolute URL to a favicon (default: `None`, NiceGUI icon will be used)
         :param dark: whether to use Quasar's dark mode (defaults to `dark` argument of `run` command)
         :param language: language of the page (defaults to `language` argument of `run` command)
+        :param shared: whether all users share the same page instance (default: ``False``, *added in version 3.x.0*)
         :param response_timeout: maximum time for the decorated function to build the page (default: 3.0 seconds)
         :param reconnect_timeout: maximum time the server waits for the browser to reconnect (defaults to `reconnect_timeout` argument of `run` command))
         :param api_router: APIRouter instance to use, can be left `None` to use the default
@@ -66,10 +70,12 @@ class page:
         self.favicon = favicon
         self.dark = dark
         self.language = language
+        self.shared = shared
         self.response_timeout = response_timeout
         self.kwargs = kwargs
         self.api_router = api_router or core.app.router
         self.reconnect_timeout = reconnect_timeout
+        self._shared_client: weakref.ref[Client] | None = None
 
         create_favicon_route(self.path, favicon)
 
@@ -152,7 +158,16 @@ class page:
             request = dec_kwargs['request']
             # NOTE cleaning up the keyword args so the signature is consistent with "func" again
             dec_kwargs = {k: v for k, v in dec_kwargs.items() if k in parameters_of_decorated_func}
+
+            # Shared page shortcut: reuse existing client if available
+            if self.shared and self._shared_client is not None and (client := self._shared_client()) is not None:
+                client._request = request  # pylint: disable=protected-access
+                binding._refresh_step()  # pylint: disable=protected-access
+                return client.build_response(request)
+
             with Client(self, request=request) as client:
+                if self.shared:
+                    self._shared_client = weakref.ref(client)
                 if any(p.name == 'client' for p in inspect.signature(func).parameters.values()):
                     dec_kwargs['client'] = client
                 try:

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import weakref
 from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
@@ -75,7 +74,7 @@ class page:
         self.kwargs = kwargs
         self.api_router = api_router or core.app.router
         self.reconnect_timeout = reconnect_timeout
-        self._shared_client: weakref.ref[Client] | None = None
+        self._shared_client: Client | None = None
         self._shared_lock: asyncio.Lock = asyncio.Lock()
 
         create_favicon_route(self.path, favicon)
@@ -160,18 +159,24 @@ class page:
             # NOTE cleaning up the keyword args so the signature is consistent with "func" again
             dec_kwargs = {k: v for k, v in dec_kwargs.items() if k in parameters_of_decorated_func}
 
-            # Shared page: reuse existing client or create one under lock to prevent races
+            # Shared page: serialize all requests under a single lock to prevent races
+            # between concurrent first-visitors creating multiple Client instances or seeing
+            # a partially-built shared client. After the shared client is fully built,
+            # subsequent requests take the fast reuse path (also under lock, but very fast).
             if self.shared:
                 async with self._shared_lock:
-                    if self._shared_client is not None and (client := self._shared_client()) is not None:
-                        client._request = request  # pylint: disable=protected-access
+                    if self._shared_client is not None:
+                        self._shared_client._request = request  # pylint: disable=protected-access
                         request.scope['nicegui_page_path'] = self.path
                         binding._refresh_step()  # pylint: disable=protected-access
-                        return client.build_response(request)
+                        return self._shared_client.build_response(request)
+                    response = await build_and_respond(request, dec_args, dec_kwargs)
+                    return response
 
+            return await build_and_respond(request, dec_args, dec_kwargs)
+
+        async def build_and_respond(request: Request, dec_args: tuple, dec_kwargs: dict) -> Response:
             with Client(self, request=request) as client:
-                if self.shared:
-                    self._shared_client = weakref.ref(client)
                 if any(p.name == 'client' for p in inspect.signature(func).parameters.values()):
                     dec_kwargs['client'] = client
                 try:
@@ -219,6 +224,9 @@ class page:
 
             if isinstance(result, Response):  # NOTE if setup returns a response, we don't need to render the page
                 return result
+            # Publish the shared client only after the page has been fully built.
+            if self.shared and self._shared_client is None:
+                self._shared_client = client
             binding._refresh_step()  # pylint: disable=protected-access
             return client.build_response(request, client.status_code)
 

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -58,7 +58,7 @@ class page:
         :param favicon: optional relative filepath or absolute URL to a favicon (default: `None`, NiceGUI icon will be used)
         :param dark: whether to use Quasar's dark mode (defaults to `dark` argument of `run` command)
         :param language: language of the page (defaults to `language` argument of `run` command)
-        :param shared: whether all users share the same page instance (default: ``False``, *added in version 3.x.0*)
+        :param shared: whether all users share the same page instance (default: ``False``)
         :param response_timeout: maximum time for the decorated function to build the page (default: 3.0 seconds)
         :param reconnect_timeout: maximum time the server waits for the browser to reconnect (defaults to `reconnect_timeout` argument of `run` command))
         :param api_router: APIRouter instance to use, can be left `None` to use the default
@@ -76,6 +76,7 @@ class page:
         self.api_router = api_router or core.app.router
         self.reconnect_timeout = reconnect_timeout
         self._shared_client: weakref.ref[Client] | None = None
+        self._shared_lock: asyncio.Lock = asyncio.Lock()
 
         create_favicon_route(self.path, favicon)
 
@@ -159,11 +160,14 @@ class page:
             # NOTE cleaning up the keyword args so the signature is consistent with "func" again
             dec_kwargs = {k: v for k, v in dec_kwargs.items() if k in parameters_of_decorated_func}
 
-            # Shared page shortcut: reuse existing client if available
-            if self.shared and self._shared_client is not None and (client := self._shared_client()) is not None:
-                client._request = request  # pylint: disable=protected-access
-                binding._refresh_step()  # pylint: disable=protected-access
-                return client.build_response(request)
+            # Shared page: reuse existing client or create one under lock to prevent races
+            if self.shared:
+                async with self._shared_lock:
+                    if self._shared_client is not None and (client := self._shared_client()) is not None:
+                        client._request = request  # pylint: disable=protected-access
+                        request.scope['nicegui_page_path'] = self.path
+                        binding._refresh_step()  # pylint: disable=protected-access
+                        return client.build_response(request)
 
             with Client(self, request=request) as client:
                 if self.shared:

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -107,6 +107,11 @@ class Storage:
         """
         if core.is_script_mode_preflight():
             return {}
+        from .context import context as ctx  # pylint: disable=import-outside-toplevel
+        if ctx.slot_stack and ctx.client.is_shared:
+            raise RuntimeError('app.storage.browser is not supported on shared pages because the request identity '
+                               'is ambiguous when multiple browsers share the same page; '
+                               'use app.storage.general instead')
         request: Request | None = request_contextvar.get()
         if request is None:
             if Storage.secret is None:
@@ -128,6 +133,11 @@ class Storage:
         """
         if core.is_script_mode_preflight():
             return PseudoPersistentDict()
+        from .context import context as ctx  # pylint: disable=import-outside-toplevel
+        if ctx.slot_stack and ctx.client.is_shared:
+            raise RuntimeError('app.storage.user is not supported on shared pages because the request identity '
+                               'is ambiguous when multiple browsers share the same page; '
+                               'use app.storage.general instead')
         request: Request | None = request_contextvar.get()
         if request is None:
             if Storage.secret is None:
@@ -153,12 +163,19 @@ class Storage:
         Like `app.storage.tab` data is unique per browser tab but is even more volatile as it is already discarded
         when the connection to the client is lost through a page reload or a navigation.
         """
-        return context.client.storage
+        client = context.client
+        if client.is_shared:
+            raise RuntimeError('app.storage.client is not supported on shared pages because all browsers share '
+                               'the same client instance; use app.storage.general instead')
+        return client.storage
 
     @property
     def tab(self) -> observables.ObservableDict:
         """A volatile storage that is only kept during the current tab session."""
         client = context.client
+        if client.is_shared:
+            raise RuntimeError('app.storage.tab is not supported on shared pages because the tab identity is ambiguous '
+                               'when multiple browsers share the same page; use app.storage.general instead')
         if not client.has_socket_connection:
             raise RuntimeError('app.storage.tab can only be used with a client connection; '
                                'see https://nicegui.io/documentation/page#wait_for_client_connection to await it')

--- a/tests/test_shared_pages.py
+++ b/tests/test_shared_pages.py
@@ -181,6 +181,26 @@ async def test_shared_and_non_shared_pages_coexist(create_user: Callable[[], Use
     assert private_client1.id != private_client2.id
 
 
+async def test_shared_page_disconnected_raises(user: User) -> None:
+    @ui.page('/', shared=True)
+    async def index():
+        ui.label('Shared Page')
+        await ui.context.client.connected()
+        with pytest.raises(RuntimeError, match='not supported on shared pages'):
+            await ui.context.client.disconnected()
+
+    await user.open('/')
+
+
+async def test_shared_page_sub_pages_raises(user: User) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        with pytest.raises(RuntimeError, match=r'ui\.sub_pages is not supported on shared pages'):
+            ui.sub_pages({'/': lambda: ui.label('Home')})
+
+    await user.open('/')
+
+
 def test_shared_page_screen_basic(screen: Screen):
     @ui.page('/', shared=True)
     def index():

--- a/tests/test_shared_pages.py
+++ b/tests/test_shared_pages.py
@@ -1,0 +1,207 @@
+from collections.abc import Callable
+
+import pytest
+
+from nicegui import Client, app, ui
+from nicegui.testing import Screen, User
+
+
+async def test_shared_page_basic(user: User) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Page')
+
+    await user.open('/')
+    await user.should_see('Shared Page')
+
+
+async def test_shared_page_reuses_client(create_user: Callable[[], User]) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Page')
+
+    user1 = create_user()
+    user2 = create_user()
+
+    await user1.open('/')
+    client1 = user1.client
+    await user2.open('/')
+    client2 = user2.client
+
+    assert client1 is not None
+    assert client2 is not None
+    assert client1.id == client2.id, 'Both users should share the same client'
+
+
+async def test_non_shared_page_creates_separate_clients(create_user: Callable[[], User]) -> None:
+    @ui.page('/')
+    def index():
+        ui.label('Private Page')
+
+    user1 = create_user()
+    user2 = create_user()
+
+    await user1.open('/')
+    client1 = user1.client
+    await user2.open('/')
+    client2 = user2.client
+
+    assert client1 is not None
+    assert client2 is not None
+    assert client1.id != client2.id, 'Each user should have their own client'
+
+
+async def test_shared_page_function_runs_only_once(create_user: Callable[[], User]) -> None:
+    call_count = 0
+
+    @ui.page('/', shared=True)
+    def index():
+        nonlocal call_count
+        call_count += 1
+        ui.label(f'Call #{call_count}')
+
+    user1 = create_user()
+    user2 = create_user()
+
+    await user1.open('/')
+    assert call_count == 1
+    await user2.open('/')
+    assert call_count == 1, 'Page function should only run once for shared pages'
+
+
+async def test_shared_page_elements_visible_to_all(create_user: Callable[[], User]) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Initial Content')
+        ui.button('Add Label', on_click=lambda: ui.label('Dynamic Content'))
+
+    user1 = create_user()
+    user2 = create_user()
+
+    await user1.open('/')
+    await user2.open('/')
+
+    user1.find('Add Label').click()
+    await user1.should_see('Dynamic Content')
+
+
+async def test_shared_page_client_not_pruned(user: User) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Page')
+
+    await user.open('/')
+    client = user.client
+    assert client is not None
+
+    # Shared clients should not be pruned even when stale
+    client_count_before = len(Client.instances)
+    Client.prune_instances(client_age_threshold=0)
+    client_count_after = len(Client.instances)
+    assert client.id in Client.instances, 'Shared client should not be pruned'
+    assert client_count_after == client_count_before
+
+
+async def test_shared_page_storage_tab_raises(user: User) -> None:
+    @ui.page('/', shared=True)
+    async def index():
+        ui.label('Shared Page')
+        await ui.context.client.connected()
+        with pytest.raises(RuntimeError, match=r'app\.storage\.tab is not supported on shared pages'):
+            _ = app.storage.tab
+
+    await user.open('/')
+
+
+async def test_shared_page_storage_client_raises(user: User) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Page')
+        with pytest.raises(RuntimeError, match=r'app\.storage\.client is not supported on shared pages'):
+            _ = app.storage.client
+
+    await user.open('/')
+
+
+async def test_shared_page_await_run_javascript_raises(user: User) -> None:
+    @ui.page('/', shared=True)
+    async def index():
+        ui.label('Shared Page')
+        await ui.context.client.connected()
+        with pytest.raises(RuntimeError, match='Cannot await run_javascript on a shared page'):
+            await ui.context.client.run_javascript('return 1')
+
+    await user.open('/')
+
+
+async def test_shared_page_is_shared_property(user: User) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Page')
+
+    await user.open('/')
+    assert user.client is not None
+    assert user.client.is_shared is True
+
+
+async def test_non_shared_page_is_shared_property(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.label('Private Page')
+
+    await user.open('/')
+    assert user.client is not None
+    assert user.client.is_shared is False
+
+
+async def test_shared_and_non_shared_pages_coexist(create_user: Callable[[], User]) -> None:
+    @ui.page('/shared', shared=True)
+    def shared():
+        ui.label('Shared Page')
+
+    @ui.page('/private')
+    def private():
+        ui.label('Private Page')
+
+    user1 = create_user()
+    user2 = create_user()
+
+    await user1.open('/shared')
+    shared_client1 = user1.client
+    await user2.open('/shared')
+    shared_client2 = user2.client
+    assert shared_client1 is not None and shared_client2 is not None
+    assert shared_client1.id == shared_client2.id
+
+    await user1.open('/private')
+    private_client1 = user1.client
+    await user2.open('/private')
+    private_client2 = user2.client
+    assert private_client1 is not None and private_client2 is not None
+    assert private_client1.id != private_client2.id
+
+
+def test_shared_page_screen_basic(screen: Screen):
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Screen Page')
+
+    screen.open('/')
+    screen.should_contain('Shared Screen Page')
+
+
+def test_shared_page_screen_reuses_across_tabs(screen: Screen):
+    client_ids: list[str] = []
+
+    @ui.page('/', shared=True)
+    def index():
+        client_ids.append(ui.context.client.id)
+        ui.label('Shared Page')
+
+    screen.open('/')
+    screen.switch_to(1)
+    screen.open('/')
+    screen.should_contain('Shared Page')
+
+    # First visit creates client, second reuses it (page function not called again)
+    assert len(client_ids) == 1, 'Page function should only run once for shared pages'

--- a/tests/test_shared_pages.py
+++ b/tests/test_shared_pages.py
@@ -83,6 +83,7 @@ async def test_shared_page_elements_visible_to_all(create_user: Callable[[], Use
 
     user1.find('Add Label').click()
     await user1.should_see('Dynamic Content')
+    await user2.should_see('Dynamic Content')
 
 
 async def test_shared_page_client_not_pruned(user: User) -> None:
@@ -119,6 +120,26 @@ async def test_shared_page_storage_client_raises(user: User) -> None:
         ui.label('Shared Page')
         with pytest.raises(RuntimeError, match=r'app\.storage\.client is not supported on shared pages'):
             _ = app.storage.client
+
+    await user.open('/')
+
+
+async def test_shared_page_storage_browser_raises(user: User) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Page')
+        with pytest.raises(RuntimeError, match=r'app\.storage\.browser is not supported on shared pages'):
+            _ = app.storage.browser
+
+    await user.open('/')
+
+
+async def test_shared_page_storage_user_raises(user: User) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Page')
+        with pytest.raises(RuntimeError, match=r'app\.storage\.user is not supported on shared pages'):
+            _ = app.storage.user
 
     await user.open('/')
 
@@ -225,3 +246,32 @@ def test_shared_page_screen_reuses_across_tabs(screen: Screen):
 
     # First visit creates client, second reuses it (page function not called again)
     assert len(client_ids) == 1, 'Page function should only run once for shared pages'
+
+
+async def test_shared_page_survives_disconnect(create_user: Callable[[], User]) -> None:
+    @ui.page('/', shared=True)
+    def index():
+        ui.label('Shared Page')
+        ui.button('Add Item', on_click=lambda: ui.label('New Item'))
+
+    user1 = create_user()
+    user2 = create_user()
+
+    await user1.open('/')
+    await user2.open('/')
+
+    client = user1.client
+    assert client is not None
+    assert client.id in Client.instances
+
+    # Simulate a disconnect by directly calling handle_disconnect with a fake socket ID
+    client._socket_to_document_id['fake-socket'] = 'fake-doc'  # pylint: disable=protected-access
+    client._num_connections['fake-doc'] = 1  # pylint: disable=protected-access
+    client.handle_disconnect('fake-socket')
+
+    # Shared client should still exist after disconnect
+    assert client.id in Client.instances, 'Shared client should survive disconnect'
+
+    # Second user should still be able to interact
+    await user2.open('/')
+    await user2.should_see('Shared Page')


### PR DESCRIPTION
## What this branch does
Implements `shared=True` on `@ui.page` so all visitors see and interact with the same page instance via a weakref-based client reuse mechanism. Includes comprehensive guiderails: RuntimeErrors for incompatible APIs (per-client storage, run_javascript, client.disconnected, ui.sub_pages) and warnings for broadcast operations (notify, download, navigate). Adds an asyncio.Lock to prevent race conditions during shared client creation. Includes 14+ tests and a guiderails documentation file.

## Status
Needs work -- includes merge commits from upstream main. The feature is functionally complete with tests and guiderails, but may need rebase and upstream review consideration (related to prior PRs #5421/#5005).

## Files changed
8 files: `nicegui/page.py`, `nicegui/client.py`, `nicegui/storage.py`, `nicegui/elements/sub_pages.py`, `nicegui/functions/navigate.py`, `nicegui/functions/notify.py`, `tests/test_shared_pages.py`, `SHARED_PAGES_GUIDERAILS.md`

## Upstream PR
None yet (related to upstream discussion in #5421 / #5005)