### PR TITLE
Full API for lang attribute on HTML tag

### DIFF
--- a/nicegui/app/app_config.py
+++ b/nicegui/app/app_config.py
@@ -34,7 +34,7 @@ class AppConfig:
     viewport: str = field(init=False)
     favicon: str | Path | None = field(init=False)
     dark: bool | None = field(init=False)
-    language: Language = field(init=False)
+    language: Language | None = field(init=False)
     binding_refresh_interval: float | None = field(init=False)
     reconnect_timeout: float = field(init=False)
     message_history_length: int = field(init=False)
@@ -52,7 +52,7 @@ class AppConfig:
                        viewport: str,
                        favicon: str | Path | None,
                        dark: bool | None,
-                       language: Language,
+                       language: Language | None,
                        binding_refresh_interval: float | None,
                        reconnect_timeout: float,
                        message_history_length: int,

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -183,6 +183,7 @@ class Client:
                 'favicon_url': get_favicon_url(self.page, prefix),
                 'dark': str(self.page.resolve_dark()),
                 'language': self.page.resolve_language(),
+                'has_explicit_language': self.page.configured_language() is not None,
                 'translations': translations.get(self.page.resolve_language(), translations['en-US']),
                 'prefix': prefix,
                 'tailwind': core.app.config.tailwind,

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -28,7 +28,7 @@ class page:
                  viewport: str | None = None,
                  favicon: str | Path | None = None,
                  dark: bool | None = ...,  # type: ignore
-                 language: Language = ...,  # type: ignore
+                 language: Language | None = ...,  # type: ignore
                  response_timeout: float = 3.0,
                  reconnect_timeout: float | None = None,
                  api_router: APIRouter | None = None,
@@ -54,7 +54,7 @@ class page:
         :param viewport: optional viewport meta tag content
         :param favicon: optional relative filepath or absolute URL to a favicon (default: `None`, NiceGUI icon will be used)
         :param dark: whether to use Quasar's dark mode (defaults to `dark` argument of `run` command)
-        :param language: language of the page (defaults to `language` argument of `run` command)
+        :param language: language of the page (defaults to `language` argument of `run` command; set explicitly to add `lang` attribute to `<html>` tag; use `None` to explicitly opt-out)
         :param response_timeout: maximum time for the decorated function to build the page (default: 3.0 seconds)
         :param reconnect_timeout: maximum time the server waits for the browser to reconnect (defaults to `reconnect_timeout` argument of `run` command))
         :param api_router: APIRouter instance to use, can be left `None` to use the default
@@ -90,9 +90,13 @@ class page:
         """Return whether the page should use dark mode."""
         return self.dark if self.dark is not ... else core.app.config.dark
 
-    def resolve_language(self) -> Language:
-        """Return the language of the page."""
+    def configured_language(self) -> Language | None:
+        """Return the explicitly configured language, or None if not set."""
         return self.language if self.language is not ... else core.app.config.language
+
+    def resolve_language(self) -> Language:
+        """Return the language of the page, falling back to 'en-US' if not explicitly set."""
+        return self.configured_language() or 'en-US'
 
     def resolve_reconnect_timeout(self) -> float:
         """Return the reconnect_timeout of the page."""

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html{% if has_explicit_language %} lang="{{ language }}"{% endif %}>
   <head>
     <title>{{ title }}</title>
     <meta name="viewport" content="{{ viewport }}" />

--- a/nicegui/testing/general.py
+++ b/nicegui/testing/general.py
@@ -17,7 +17,7 @@ def prepare_simulation() -> None:
         viewport='',
         favicon=None,
         dark=False,
-        language='en-US',
+        language=None,
         binding_refresh_interval=0.1,
         reconnect_timeout=3.0,
         message_history_length=1000,

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -54,7 +54,7 @@ def run(root: Callable | None = None, *,
         viewport: str = 'width=device-width, initial-scale=1',
         favicon: str | Path | None = None,
         dark: bool | None = False,
-        language: Language = 'en-US',
+        language: Language | None = None,
         binding_refresh_interval: float | None = 0.1,
         reconnect_timeout: float = 3.0,
         message_history_length: int = 1000,
@@ -93,7 +93,7 @@ def run(root: Callable | None = None, *,
     :param viewport: page meta viewport content (default: `'width=device-width, initial-scale=1'`, can be overwritten per page)
     :param favicon: relative filepath, absolute URL to a favicon (default: `None`, NiceGUI icon will be used) or emoji (e.g. `'🚀'`, works for most browsers)
     :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
-    :param language: language for Quasar elements (default: `'en-US'`)
+    :param language: language for Quasar elements (default: `None`, which uses `'en-US'` for Quasar but does not add `lang` attribute to `<html>` tag; set explicitly to add the attribute)
     :param binding_refresh_interval: interval for updating active links (default: 0.1 seconds, bigger is more CPU friendly, *since version 3.4.0*: can be ``None`` to disable update loop)
     :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 3.0 seconds)
     :param message_history_length: maximum number of messages that will be stored and resent after a connection interruption (default: 1000, use 0 to disable, *added in version 2.9.0*)

--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -25,7 +25,7 @@ def run_with(
     viewport: str = 'width=device-width, initial-scale=1',
     favicon: str | Path | None = None,
     dark: bool | None = False,
-    language: Language = 'en-US',
+    language: Language | None = None,
     binding_refresh_interval: float | None = 0.1,
     reconnect_timeout: float = 3.0,
     message_history_length: int = 1000,
@@ -48,7 +48,7 @@ def run_with(
     :param viewport: page meta viewport content (default: `'width=device-width, initial-scale=1'`, can be overwritten per page)
     :param favicon: relative filepath, absolute URL to a favicon (default: `None`, NiceGUI icon will be used) or emoji (e.g. `'🚀'`, works for most browsers)
     :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
-    :param language: language for Quasar elements (default: `'en-US'`)
+    :param language: language for Quasar elements (default: `None`, which uses `'en-US'` for Quasar but does not add `lang` attribute to `<html>` tag; set explicitly to add the attribute)
     :param binding_refresh_interval: interval for updating active links (default: 0.1 seconds, bigger is more CPU friendly, *since version 3.4.0*: can be ``None`` to disable update loop)
     :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 3.0 seconds)
     :param message_history_length: maximum number of messages that will be stored and resent after a connection interruption (default: 1000, use 0 to disable, *added in version 2.9.0*)

--- a/tests/test_lang_attribute.py
+++ b/tests/test_lang_attribute.py
@@ -1,0 +1,85 @@
+"""Tests for the lang attribute in the HTML tag."""
+import re
+
+import httpx
+import pytest
+
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+def _get_html_tag(url: str) -> str:
+    """Fetch the page and return the <html ...> opening tag."""
+    response = httpx.get(url)
+    match = re.search(r'<html[^>]*>', response.text, re.IGNORECASE)
+    assert match, 'Could not find <html> tag in response'
+    return match.group(0)
+
+
+def test_no_lang_attribute_by_default(screen: Screen):
+    """Test that lang attribute is not added when language is not explicitly set."""
+    @ui.page('/')
+    def page():
+        ui.label('Hello')
+
+    screen.open('/')
+    html_tag = _get_html_tag(screen.url)
+    assert 'lang=' not in html_tag.lower(), \
+        f'lang attribute should not be in HTML tag when not explicitly set, but got: {html_tag}'
+
+
+@pytest.mark.parametrize('language_code,expected_lang', [
+    ('fr', 'fr'),
+    ('zh-CN', 'zh-CN'),
+    ('pt-BR', 'pt-BR'),
+])
+def test_lang_attribute_with_explicit_language(screen: Screen, language_code: str, expected_lang: str):
+    """Test that lang attribute is added when language is explicitly set and full codes are preserved."""
+    @ui.page('/', language=language_code)
+    def page():
+        ui.label('Test')
+
+    screen.open('/')
+    html_tag = _get_html_tag(screen.url)
+    assert f'lang="{expected_lang}"' in html_tag, \
+        f'lang attribute should be "{expected_lang}", got: {html_tag}'
+
+
+def test_none_language_opts_out(screen: Screen):
+    """Test that None language explicitly opts out of lang attribute."""
+    @ui.page('/', language=None)
+    def page():
+        ui.label('Test')
+
+    screen.open('/')
+    html_tag = _get_html_tag(screen.url)
+    assert 'lang=' not in html_tag.lower(), \
+        f'lang attribute should not be in HTML tag when None is used, but got: {html_tag}'
+
+
+def test_none_overrides_global_language(screen: Screen):
+    """Test that page language=None opts out even when global config sets a language."""
+    screen.ui_run_kwargs['language'] = 'de'
+
+    @ui.page('/', language=None)
+    def page():
+        ui.label('Test')
+
+    screen.open('/')
+    html_tag = _get_html_tag(screen.url)
+    assert 'lang=' not in html_tag.lower(), \
+        f'lang attribute should not be present when page opts out with None, but got: {html_tag}'
+
+
+def test_global_language_inherited_by_page(screen: Screen):
+    """Test that pages inherit the lang attribute from global config."""
+    screen.ui_run_kwargs['language'] = 'de'
+
+    @ui.page('/')
+    def page():
+        ui.label('Test')
+
+    screen.open('/')
+    html_tag = _get_html_tag(screen.url)
+    assert 'lang="de"' in html_tag, \
+        f'lang attribute should be "de" when inherited from global config, got: {html_tag}'


### PR DESCRIPTION
## What this branch does
Adds opt-in `lang` attribute support on the `<html>` tag with per-page override and global app config. Setting `language=None` explicitly opts out of the lang attribute while still using 'en-US' for Quasar's language. Aligns `ui.run_with()` default with `ui.run()` (both default to `language=None`). Includes dedicated tests for global language inheritance. More comprehensive than upstream PR #5811 which is template-only.

## Status
Ready — single clean commit, touches core files but changes are minimal and backward-compatible.

## Files changed
8 files: `nicegui/app/app_config.py`, `nicegui/client.py`, `nicegui/page.py`, `nicegui/templates/index.html`, `nicegui/testing/general.py`, `nicegui/ui_run.py`, `nicegui/ui_run_with.py`, `tests/test_lang_attribute.py` (new).

## Upstream PR
Related: upstream #5811 (template-only approach; this branch is more comprehensive with full API support)