### PR TITLE
Docs: widescreen layout for quick-reference sidebar

### DIFF
--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -21,12 +21,15 @@ class Attribute:
 
 def generate_class_doc(class_obj: type, part_title: str, *,
                        side_panel: Element | None = None) -> None:
-    """Generate documentation for a class including all its methods and properties.
-
-    :param side_panel: If provided, render Initializer and Properties into this container
-                       while Methods and Inheritance render in the current context.
-    """
+    """Generate documentation for a class including all its methods and properties."""
     doc = class_obj.__doc__ or class_obj.__init__.__doc__
+    _side = side_panel if side_panel is not None else contextlib.nullcontext()
+    with _side:
+        if doc and ':param' in doc:
+            subheading('Initializer', anchor_name=create_anchor_name(part_title.replace('Reference', 'Initializer')))
+            description = remove_indentation(doc.split('\n', 1)[-1])
+            lines = [line.replace(':param ', ':') for line in description.splitlines() if ':param' in line]
+            custom_restructured_text('\n'.join(lines)).classes('bold-links arrow-links rst-param-tables')
 
     mro = [base for base in class_obj.__mro__ if base.__module__.startswith('nicegui.')]
     ancestors = mro[1:]
@@ -39,13 +42,7 @@ def generate_class_doc(class_obj: type, part_title: str, *,
     properties = [attribute for attribute in attributes if not callable(attribute.obj)]
     methods = [attribute for attribute in attributes if callable(attribute.obj)]
 
-    with side_panel if side_panel is not None else contextlib.nullcontext():
-        if doc and ':param' in doc:
-            subheading('Initializer', anchor_name=create_anchor_name(part_title.replace('Reference', 'Initializer')))
-            description = remove_indentation(doc.split('\n', 1)[-1])
-            lines = [line.replace(':param ', ':') for line in description.splitlines() if ':param' in line]
-            custom_restructured_text('\n'.join(lines)).classes('bold-links arrow-links rst-param-tables')
-
+    with _side:
         if properties:
             subheading('Properties', anchor_name=create_anchor_name(part_title.replace('Reference', 'Properties')))
             _render_section(class_obj, properties, method_section=False)

--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -1,9 +1,11 @@
+import contextlib
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
 
 from nicegui import binding, ui
 from nicegui.dataclasses import KWONLY_SLOTS
+from nicegui.element import Element
 from nicegui.elements.markdown import remove_indentation
 
 from ..style import create_anchor_name, subheading
@@ -17,14 +19,14 @@ class Attribute:
     base: type
 
 
-def generate_class_doc(class_obj: type, part_title: str) -> None:
-    """Generate documentation for a class including all its methods and properties."""
+def generate_class_doc(class_obj: type, part_title: str, *,
+                       side_panel: Element | None = None) -> None:
+    """Generate documentation for a class including all its methods and properties.
+
+    :param side_panel: If provided, render Initializer and Properties into this container
+                       while Methods and Inheritance render in the current context.
+    """
     doc = class_obj.__doc__ or class_obj.__init__.__doc__
-    if doc and ':param' in doc:
-        subheading('Initializer', anchor_name=create_anchor_name(part_title.replace('Reference', 'Initializer')))
-        description = remove_indentation(doc.split('\n', 1)[-1])
-        lines = [line.replace(':param ', ':') for line in description.splitlines() if ':param' in line]
-        custom_restructured_text('\n'.join(lines)).classes('bold-links arrow-links rst-param-tables')
 
     mro = [base for base in class_obj.__mro__ if base.__module__.startswith('nicegui.')]
     ancestors = mro[1:]
@@ -37,9 +39,16 @@ def generate_class_doc(class_obj: type, part_title: str) -> None:
     properties = [attribute for attribute in attributes if not callable(attribute.obj)]
     methods = [attribute for attribute in attributes if callable(attribute.obj)]
 
-    if properties:
-        subheading('Properties', anchor_name=create_anchor_name(part_title.replace('Reference', 'Properties')))
-        _render_section(class_obj, properties, method_section=False)
+    with side_panel if side_panel is not None else contextlib.nullcontext():
+        if doc and ':param' in doc:
+            subheading('Initializer', anchor_name=create_anchor_name(part_title.replace('Reference', 'Initializer')))
+            description = remove_indentation(doc.split('\n', 1)[-1])
+            lines = [line.replace(':param ', ':') for line in description.splitlines() if ':param' in line]
+            custom_restructured_text('\n'.join(lines)).classes('bold-links arrow-links rst-param-tables')
+
+        if properties:
+            subheading('Properties', anchor_name=create_anchor_name(part_title.replace('Reference', 'Properties')))
+            _render_section(class_obj, properties, method_section=False)
 
     if methods:
         subheading('Methods', anchor_name=create_anchor_name(part_title.replace('Reference', 'Methods')))

--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -6,11 +6,16 @@ from .custom_restructured_text import CustomRestructuredText as custom_restructu
 from .demo import demo
 from .reference import generate_class_doc
 
+WIDE = 'min-[2001px]'
+
 
 def render_page(documentation: DocumentationPage) -> None:
     """Render the documentation."""
     title = (documentation.title or '').replace('*', '')
     ui.page_title('NiceGUI' if not title else title if title.split()[0] == 'NiceGUI' else f'{title} | NiceGUI')
+
+    reference_parts = [(p.reference, p.title) for p in documentation.parts if p.reference]
+    side_panels: list[ui.column] = []
 
     def render_content():
         section_heading(documentation.subtitle or '', documentation.heading)
@@ -34,17 +39,82 @@ def render_page(documentation: DocumentationPage) -> None:
             if part.demo:
                 demo(part.demo.function, lazy=part.demo.lazy, tab=part.demo.tab)
             if part.reference:
-                generate_class_doc(part.reference, part.title)
+                if reference_parts:
+                    panel = ui.column().classes('w-full')
+                    side_panels.append(panel)
+                    generate_class_doc(part.reference, part.title, side_panel=panel)
+                else:
+                    generate_class_doc(part.reference, part.title)
             if part.link:
                 ui.markdown(f'See [more...](/documentation/{part.link})').classes('bold-links arrow-links')
-    with ui.column().classes('w-full p-8 lg:p-16 max-w-[1250px] mx-auto'):
-        if documentation.extra_column:
-            with ui.grid().classes('grid-cols-[2fr_1fr] max-[600px]:grid-cols-[1fr] gap-x-8 gap-y-16'):
+
+    row = ui.row().classes(f'w-full justify-center items-start {WIDE}:!gap-0')
+    if reference_parts:
+        row.classes(f'{WIDE}:h-[calc(100vh-70px)] {WIDE}:overflow-hidden')
+    with row:
+        main_col = ui.column().classes(f'w-full p-8 lg:p-16 max-w-[1250px] mx-auto {WIDE}:!mx-0')
+        if reference_parts:
+            main_col.classes(f'{WIDE}:h-full {WIDE}:!p-0 {WIDE}:!gap-0')
+        with main_col:
+            if reference_parts:
+                scroll = ui.element('div').classes(
+                    f'w-full {WIDE}:overflow-y-auto {WIDE}:h-full {WIDE}:p-8 lg:{WIDE}:p-16'
+                )
+            else:
+                scroll = ui.element('div').classes('w-full')
+            with scroll:
                 with ui.column().classes('w-full'):
-                    render_content()
-                with ui.column():
-                    documentation.extra_column()
-        else:
-            render_content()
-    with ui.column().classes('w-full p-4 items-end'):
-        ui.link('Imprint & Privacy', '/imprint_privacy').classes('text-sm')
+                    if documentation.extra_column:
+                        with ui.grid().classes('grid-cols-[2fr_1fr] max-[600px]:grid-cols-[1fr] gap-x-8 gap-y-16'):
+                            with ui.column().classes('w-full'):
+                                render_content()
+                            with ui.column():
+                                documentation.extra_column()
+                    else:
+                        render_content()
+                    with ui.column().classes('w-full p-4 items-end'):
+                        ui.link('Imprint & Privacy', '/imprint_privacy').classes('text-sm')
+        if reference_parts:
+            side = ui.element('div').classes(
+                f'!hidden {WIDE}:!block max-w-[500px] shrink-0'
+                f' {WIDE}:overflow-y-auto {WIDE}:h-full'
+            )
+            with side:
+                ui.column().classes('w-full p-8 lg:p-16').props(f'id="side-panel-{side.id}"')
+            _setup_side_panel_js(side_panels, side)
+
+
+def _setup_side_panel_js(panels: list[ui.column], side: ui.element) -> None:
+    """Set up JavaScript to move side panel content between main and side column based on viewport width."""
+    if not panels:
+        return
+    ids = [f'c{panel.id}' for panel in panels]
+    side_inner_id = f'side-panel-{side.id}'
+    ui.run_javascript(f'''
+        (function setup() {{
+            const ids = {ids};
+            const sideInner = document.getElementById("{side_inner_id}");
+            const elements = ids.map(id => document.getElementById(id));
+            if (!sideInner || elements.some(el => !el)) {{
+                requestAnimationFrame(setup);
+                return;
+            }}
+            const mql = window.matchMedia("(min-width: 2001px)");
+            const placeholders = elements.map(el => {{
+                const ph = document.createComment("side-ph");
+                el.parentNode.insertBefore(ph, el);
+                return {{ el, ph }};
+            }});
+            function update(e) {{
+                placeholders.forEach(({{ el, ph }}) => {{
+                    if (e.matches) {{
+                        sideInner.appendChild(el);
+                    }} else {{
+                        ph.parentNode.insertBefore(el, ph);
+                    }}
+                }});
+            }}
+            mql.addEventListener("change", update);
+            update(mql);
+        }})();
+    ''')

--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -14,7 +14,7 @@ def render_page(documentation: DocumentationPage) -> None:
     title = (documentation.title or '').replace('*', '')
     ui.page_title('NiceGUI' if not title else title if title.split()[0] == 'NiceGUI' else f'{title} | NiceGUI')
 
-    reference_parts = [(p.reference, p.title) for p in documentation.parts if p.reference]
+    has_reference = any(p.reference for p in documentation.parts)
     side_panels: list[ui.column] = []
 
     def render_content():
@@ -39,24 +39,21 @@ def render_page(documentation: DocumentationPage) -> None:
             if part.demo:
                 demo(part.demo.function, lazy=part.demo.lazy, tab=part.demo.tab)
             if part.reference:
-                if reference_parts:
-                    panel = ui.column().classes('w-full')
-                    side_panels.append(panel)
-                    generate_class_doc(part.reference, part.title, side_panel=panel)
-                else:
-                    generate_class_doc(part.reference, part.title)
+                panel = ui.column().classes('w-full')
+                side_panels.append(panel)
+                generate_class_doc(part.reference, part.title, side_panel=panel)
             if part.link:
                 ui.markdown(f'See [more...](/documentation/{part.link})').classes('bold-links arrow-links')
 
     row = ui.row().classes(f'w-full justify-center items-start {WIDE}:!gap-0')
-    if reference_parts:
+    if has_reference:
         row.classes(f'{WIDE}:h-[calc(100vh-70px)] {WIDE}:overflow-hidden')
     with row:
-        main_col = ui.column().classes(f'w-full p-8 lg:p-16 max-w-[1250px] mx-auto {WIDE}:!mx-0')
-        if reference_parts:
-            main_col.classes(f'{WIDE}:h-full {WIDE}:!p-0 {WIDE}:!gap-0')
+        main_col = ui.column().classes('w-full p-8 lg:p-16 max-w-[1250px] mx-auto')
+        if has_reference:
+            main_col.classes(f'{WIDE}:!mx-0 {WIDE}:h-full {WIDE}:!p-0 {WIDE}:!gap-0')
         with main_col:
-            if reference_parts:
+            if has_reference:
                 scroll = ui.element('div').classes(
                     f'w-full {WIDE}:overflow-y-auto {WIDE}:h-full {WIDE}:p-8 lg:{WIDE}:p-16'
                 )
@@ -74,7 +71,7 @@ def render_page(documentation: DocumentationPage) -> None:
                         render_content()
                     with ui.column().classes('w-full p-4 items-end'):
                         ui.link('Imprint & Privacy', '/imprint_privacy').classes('text-sm')
-        if reference_parts:
+        if has_reference:
             side = ui.element('div').classes(
                 f'!hidden {WIDE}:!block max-w-[500px] shrink-0'
                 f' {WIDE}:overflow-y-auto {WIDE}:h-full'


### PR DESCRIPTION
## What this branch does
Adjusts the documentation rendering so the quick-reference sidebar uses a wider, widescreen-friendly layout. Changes span `reference.py` (sidebar construction) and `rendering.py` (column widths / layout logic), replacing the reference parts list with a simple boolean and reusing the existing context manager for the side column.

## Status
Low priority / Minor improvement. Note: upstream Discussion #5794 received lukewarm reception, with feedback that the wider layout "puts strain on the eyes."

## Files changed
2 files (2 commits): `website/documentation/reference.py`, `website/documentation/rendering.py`.

## Upstream PR
None yet