### PR TITLE
Experiment: i18n via gettext/Babel with URL-based routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv
 .DS_Store
 .env
 node_modules/
+*.mo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
             nicegui/static/dompurify\..*|
             nicegui/static/unocss/.*|
             nicegui/translations\.py|
+            website/translations/.*|
             website/static/fuse\.js\@.*|
           )$
         additional_dependencies:

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,4 @@
+# Babel extraction configuration for the NiceGUI website.
+# Extract translatable strings from t() calls in website/ Python files.
+[python: website/**.py]
+encoding = utf-8

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from starlette.responses import Response
 from nicegui import app, core, ui
 from nicegui.page_arguments import RouteMatch
 from website import documentation, examples_page, fly, header, imprint_privacy, main_page, rate_limits, svg
+from website.i18n import SUPPORTED_LANGUAGES, get_url_prefix, set_language
 
 
 @app.add_middleware
@@ -52,12 +53,11 @@ class custom_sub_pages(ui.sub_pages):
         return super()._render_page(match)
 
 
-@ui.page('/')
-@ui.page('/examples')
-@ui.page('/documentation')
-@ui.page('/documentation/{path:path}')
-@ui.page('/imprint_privacy')
-def _main_page() -> None:
+def _build_page(lang: str = 'en') -> None:
+    """Build the page content for a given language."""
+    set_language(lang)
+    prefix = get_url_prefix()
+
     ui.context.client.content.classes('p-0 gap-0')
     header.add_head_html()
 
@@ -65,7 +65,7 @@ def _main_page() -> None:
             .classes('column no-wrap gap-1 bg-[#eee] dark:bg-[#1b1b1b] mt-[-20px] px-8 py-20') \
             .style('height: calc(100% + 20px) !important') as menu:
         tree = ui.tree(documentation.tree.nodes, label_key='title',
-                       on_select=lambda e: ui.navigate.to(f'/documentation/{e.value}')) \
+                       on_select=lambda e: ui.navigate.to(f'{prefix}/documentation/{e.value}')) \
             .classes('w-full').props('accordion no-connectors no-selection-unset')
     menu_button = header.add_header(menu)
 
@@ -83,12 +83,12 @@ def _main_page() -> None:
         '/': main_page.create,
         '/examples': examples_page.create,
         '/documentation': lambda: documentation.render_page(documentation.registry['']),
-        '/documentation/{name}': lambda name: _documentation_detail_page(name, tree),
+        '/documentation/{name}': lambda name: _documentation_detail_page(name, tree, prefix),
         '/imprint_privacy': imprint_privacy.create,
-    }, show_404=False).classes('w-full')
+    }, root_path=prefix or None, show_404=False).classes('w-full')
 
     def _update_menu(path: str):
-        if path.startswith('/documentation/'):
+        if '/documentation/' in path:
             menu_button.visible = True
             if window_state['is_desktop'] is not None:
                 menu.value = window_state['is_desktop']
@@ -99,13 +99,45 @@ def _main_page() -> None:
     _update_menu(ui.context.client.sub_pages_router.current_path)
 
 
-def _documentation_detail_page(name: str, tree: ui.tree) -> None:
+@ui.page('/')
+@ui.page('/examples')
+@ui.page('/documentation')
+@ui.page('/documentation/{path:path}')
+@ui.page('/imprint_privacy')
+def _main_page() -> None:
+    _build_page('en')
+
+
+# Register language-prefixed routes for each supported language (except English).
+for _lang in SUPPORTED_LANGUAGES:
+    if _lang == 'en':
+        continue
+
+    def _make_i18n_handler(lang: str):
+        def handler() -> None:
+            _build_page(lang)
+        handler.__name__ = f'_i18n_page_{lang}'
+        handler.__qualname__ = f'_i18n_page_{lang}'
+        return handler
+
+    _handler = _make_i18n_handler(_lang)
+    for _route in [
+        f'/{_lang}',
+        f'/{_lang}/examples',
+        f'/{_lang}/documentation',
+        f'/{_lang}/documentation/{{path:path}}',
+        f'/{_lang}/imprint_privacy',
+    ]:
+        _handler = ui.page(_route)(_handler)
+
+
+def _documentation_detail_page(name: str, tree: ui.tree, prefix: str) -> None:
     tree.props.update(expanded=documentation.tree.ancestors(name))
     tree.update()
     if name in documentation.registry:
         documentation.render_page(documentation.registry[name])
     elif name in documentation.redirects:
-        ui.navigate.to('/documentation/' + documentation.redirects[name])
+        ui.navigate.to(f'{prefix}/documentation/' + documentation.redirects[name])
     else:
         ui.label(f'Documentation for "{name}" could not be found.').classes('absolute-center')
 
@@ -116,4 +148,4 @@ def _status():
 
 
 # NOTE: do not reload on fly.io (see https://github.com/zauberzeug/nicegui/discussions/1720#discussioncomment-7288741)
-ui.run(uvicorn_reload_includes='*.py, *.css, *.html', reload=not on_fly, reconnect_timeout=10.0)
+ui.run(uvicorn_reload_includes='*.py, *.css, *.html, *.json', reload=not on_fly, reconnect_timeout=10.0)

--- a/website/documentation/intro.py
+++ b/website/documentation/intro.py
@@ -3,21 +3,22 @@ from collections.abc import Callable
 
 from nicegui import ui
 
+from ..i18n import t
 from ..style import subheading
 from .content.sub_pages_documentation import FakeSubPages
 from .demo import demo
 
 
 def create_intro() -> None:
-    @_main_page_demo('Single-Page Applications', '''
-        Build applications with fast client-side routing using [`ui.sub_pages`](/documentation/sub_pages)
-        and a `root` function as single entry point.
-        For each visitor, the `root` function is executed and generates the interface.
-        [`ui.link`](/documentation/link) and [`ui.navigate`](/documentation/navigate) can be used to navigate to other sub pages.
-
-        If you do not want a single-page application, you can also use [`@ui.page('/your/path')`](/documentation/page)
-        to define standalone content available at a specific path.
-    ''')
+    @_main_page_demo(t('Single-Page Applications'), t(
+        'Build applications with fast client-side routing using [`ui.sub_pages`](/documentation/sub_pages)\n'
+        'and a `root` function as single entry point.\n'
+        'For each visitor, the `root` function is executed and generates the interface.\n'
+        '[`ui.link`](/documentation/link) and [`ui.navigate`](/documentation/navigate) can be used to navigate to other sub pages.\n'
+        '\n'
+        "If you do not want a single-page application, you can also use [`@ui.page('/your/path')`](/documentation/page)\n"
+        'to define standalone content available at a specific path.'
+    ))
     def spa_demo():
         sub_pages = None  # HIDE
 
@@ -46,12 +47,12 @@ def create_intro() -> None:
 
         return root
 
-    @_main_page_demo('Reactive Transformations', '''
-        Create real-time interfaces with automatic updates.
-        Type and watch text flow in both directions.
-        When input changes, the [binding](/documentation/section_binding_properties) transforms the text
-        with a custom Python function and updates the label.
-    ''')
+    @_main_page_demo(t('Reactive Transformations'), t(
+        'Create real-time interfaces with automatic updates.\n'
+        'Type and watch text flow in both directions.\n'
+        'When input changes, the [binding](/documentation/section_binding_properties) transforms the text\n'
+        'with a custom Python function and updates the label.'
+    ))
     def binding_demo():
         def root():
             user_input = ui.input(value='Hello')
@@ -62,12 +63,12 @@ def create_intro() -> None:
 
         return root
 
-    @_main_page_demo('Event System', '''
-        Use an [Event](/documentation/event) to trigger actions and pass data.
-        Here we have an IoT temperature sensor submitting its readings
-        to a [FastAPI endpoint](/documentation/section_pages_routing#api_responses) with path "/sensor".
-        When a new value arrives, it emits an event for the chart to be updated.
-    ''')
+    @_main_page_demo(t('Event System'), t(
+        'Use an [Event](/documentation/event) to trigger actions and pass data.\n'
+        'Here we have an IoT temperature sensor submitting its readings\n'
+        'to a [FastAPI endpoint](/documentation/section_pages_routing#api_responses) with path "/sensor".\n'
+        'When a new value arrives, it emits an event for the chart to be updated.'
+    ))
     def event_system_demo():
         import time
 

--- a/website/examples_page.py
+++ b/website/examples_page.py
@@ -1,13 +1,14 @@
 from nicegui import ui
 
 from .examples import examples
+from .i18n import t
 from .style import example_link, link_target, section_heading
 
 
 def create() -> None:
     with ui.column().classes('w-full p-8 lg:p-16 max-w-[1600px] mx-auto'):
         link_target('examples')
-        section_heading('In-depth examples', 'Pick your *solution*')
+        section_heading(t('In-depth examples'), t('Pick your *solution*'))
         with ui.row().classes('w-full text-lg leading-tight grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4'):
             for example in examples:
                 example_link(example)

--- a/website/header.py
+++ b/website/header.py
@@ -1,9 +1,11 @@
+import json
 import os
 from pathlib import Path
 
 from nicegui import app, ui
 
 from . import svg
+from .i18n import SUPPORTED_LANGUAGES, get_url_prefix, t
 from .search import Search
 from .star import add_star
 
@@ -23,13 +25,14 @@ def add_head_html() -> None:
 
 def add_header(menu: ui.left_drawer) -> ui.button:
     """Create the page header."""
+    prefix = get_url_prefix()
     menu_items = {
-        'Installation': '/#installation',
-        'Features': '/#features',
-        'Demos': '/#demos',
-        'Documentation': '/documentation',
-        'Examples': '/examples',
-        'Why?': '/#why',
+        t('Installation'): f'{prefix}/#installation',
+        t('Features'): f'{prefix}/#features',
+        t('Demos'): f'{prefix}/#demos',
+        t('Documentation'): f'{prefix}/documentation',
+        t('Examples'): f'{prefix}/examples',
+        t('Why?'): f'{prefix}/#why',
     }
     dark_mode = ui.dark_mode(value=app.storage.browser.get('dark_mode'), on_change=lambda e: ui.run_javascript(f'''
         fetch('/dark_mode', {{
@@ -42,7 +45,7 @@ def add_header(menu: ui.left_drawer) -> ui.button:
             .classes('items-center duration-200 p-0 px-4 no-wrap') \
             .style('box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1)'):
         menu_button = ui.button(on_click=menu.toggle, icon='menu').props('flat color=white round').classes('lg:hidden')
-        with ui.link(target='/').classes('row gap-4 items-center no-wrap mr-auto'):
+        with ui.link(target=f'{prefix}/').classes('row gap-4 items-center no-wrap mr-auto'):
             svg.face().classes('w-8 stroke-white stroke-2 max-[610px]:hidden')
             svg.word().classes('w-24')
 
@@ -53,7 +56,7 @@ def add_header(menu: ui.left_drawer) -> ui.button:
         search = Search()
         search.create_button()
 
-        with ui.element().classes('max-[420px]:hidden').tooltip('Cycle theme mode through dark, light, and system/auto.'):
+        with ui.element().classes('max-[420px]:hidden').tooltip(t('Cycle theme mode through dark, light, and system/auto.')):
             ui.button(icon='dark_mode', on_click=lambda: dark_mode.set_value(None)) \
                 .props('flat fab-mini color=white').bind_visibility_from(dark_mode, 'value', value=True)
             ui.button(icon='light_mode', on_click=lambda: dark_mode.set_value(True)) \
@@ -61,14 +64,16 @@ def add_header(menu: ui.left_drawer) -> ui.button:
             ui.button(icon='brightness_auto', on_click=lambda: dark_mode.set_value(False)) \
                 .props('flat fab-mini color=white').bind_visibility_from(dark_mode, 'value', lambda mode: mode is None)
 
-        with ui.link(target='https://discord.gg/TEpFeAaF4f').classes('max-[515px]:hidden').tooltip('Discord'):
+        with ui.link(target='https://discord.gg/TEpFeAaF4f').classes('max-[515px]:hidden').tooltip(t('Discord')):
             svg.discord().classes('fill-white scale-125 m-1')
-        with ui.link(target='https://www.reddit.com/r/nicegui/').classes('max-[465px]:hidden').tooltip('Reddit'):
+        with ui.link(target='https://www.reddit.com/r/nicegui/').classes('max-[465px]:hidden').tooltip(t('Reddit')):
             svg.reddit().classes('fill-white scale-125 m-1')
-        with ui.link(target='https://github.com/zauberzeug/nicegui/').classes('max-[365px]:hidden').tooltip('GitHub'):
+        with ui.link(target='https://github.com/zauberzeug/nicegui/').classes('max-[365px]:hidden').tooltip(t('GitHub')):
             svg.github().classes('fill-white scale-125 m-1')
 
         add_star().classes('max-[550px]:hidden')
+
+        _add_language_selector()
 
         with ui.row().classes('min-[1051px]:hidden'):
             with ui.button(icon='more_vert').props('flat color=white round'):
@@ -77,3 +82,30 @@ def add_header(menu: ui.left_drawer) -> ui.button:
                         ui.menu_item(title_, on_click=lambda target=target: ui.navigate.to(target))
 
     return menu_button
+
+
+def _add_language_selector() -> None:
+    """Add a language selector dropdown to the header."""
+
+    def switch_language(lang: str) -> None:
+        new_prefix = f'/{lang}' if lang != 'en' else ''
+        prefixes_js = json.dumps([f'/{code}' for code in SUPPORTED_LANGUAGES if code != 'en'])
+        new_prefix_js = json.dumps(new_prefix)
+        ui.run_javascript(f'''
+            const path = window.location.pathname;
+            const prefixes = {prefixes_js};
+            const newPrefix = {new_prefix_js};
+            let basePath = path;
+            for (const p of prefixes) {{
+                if (path.startsWith(p + '/') || path === p) {{
+                    basePath = path.substring(p.length) || '/';
+                    break;
+                }}
+            }}
+            window.location.href = newPrefix + basePath;
+        ''')
+
+    with ui.button(icon='language').props('flat color=white round').classes('max-[470px]:hidden'):
+        with ui.menu().classes('bg-primary text-white'):
+            for lang, name in SUPPORTED_LANGUAGES.items():
+                ui.menu_item(name, on_click=lambda lang=lang: switch_language(lang))

--- a/website/i18n.py
+++ b/website/i18n.py
@@ -1,0 +1,101 @@
+"""Internationalization (i18n) support for the NiceGUI website.
+
+Provides a translation function ``t()`` backed by gettext ``.po`` catalogs.
+Language is resolved per-request via a ``ContextVar``, which is async-safe.
+``.po`` files are compiled to ``.mo`` on the fly when missing or stale,
+so committing or manually generating ``.mo`` files is not required.
+
+Workflow (requires Babel as a dev dependency)::
+
+    # Extract translatable strings from source code
+    pybabel extract -F babel.cfg -k t -o website/translations/messages.pot .
+
+    # Create a new language catalog (first time only)
+    pybabel init -i website/translations/messages.pot -d website/translations -l <lang>
+
+    # Update existing catalogs after source strings change
+    pybabel update -i website/translations/messages.pot -d website/translations
+"""
+from __future__ import annotations
+
+import gettext
+from contextvars import ContextVar
+from pathlib import Path
+
+# URL slug -> display name
+SUPPORTED_LANGUAGES: dict[str, str] = {
+    'en': 'English',
+    'de': 'Deutsch',
+    'ja': '日本語',
+    'ko': '한국어',
+    'zh': '中文',
+}
+
+_TRANSLATIONS_DIR = Path(__file__).parent / 'translations'
+
+_current_language: ContextVar[str] = ContextVar('_current_language', default='en')
+_url_prefix: ContextVar[str] = ContextVar('_url_prefix', default='')
+
+_cache: dict[str, gettext.GNUTranslations | gettext.NullTranslations] = {}
+
+
+def _ensure_mo(lang: str) -> None:
+    """Compile ``<lang>/LC_MESSAGES/messages.po`` to ``.mo`` if missing or stale."""
+    po = _TRANSLATIONS_DIR / lang / 'LC_MESSAGES' / 'messages.po'
+    mo = po.with_suffix('.mo')
+    if not po.exists():
+        return
+    if mo.exists() and mo.stat().st_mtime >= po.stat().st_mtime:
+        return
+    from babel.messages.mofile import write_mo
+    from babel.messages.pofile import read_po
+    with open(po, 'rb') as po_file:
+        catalog = read_po(po_file)
+    with open(mo, 'wb') as mo_file:
+        write_mo(mo_file, catalog)
+
+
+def _load_catalog(lang: str) -> gettext.GNUTranslations | gettext.NullTranslations:
+    """Load the gettext catalog for *lang*, returning a cached copy if available."""
+    if lang not in _cache:
+        _ensure_mo(lang)
+        _cache[lang] = gettext.translation(
+            'messages',
+            localedir=str(_TRANSLATIONS_DIR),
+            languages=[lang],
+            fallback=True,
+        )
+    return _cache[lang]
+
+
+def set_language(lang: str) -> None:
+    """Set the language for the current request context."""
+    _current_language.set(lang)
+    _url_prefix.set(f'/{lang}' if lang != 'en' else '')
+
+
+def get_language() -> str:
+    """Return the current request language."""
+    return _current_language.get()
+
+
+def get_url_prefix() -> str:
+    """Return the URL path prefix for the current language (empty for English)."""
+    return _url_prefix.get()
+
+
+def t(english: str) -> str:
+    """Look up a translated string for the current language.
+
+    Uses the English text as the message ID.  Falls back to the original
+    English string when no translation is available.  Internal documentation
+    links are rewritten to include the current language prefix.
+    """
+    lang = _current_language.get()
+    if lang == 'en':
+        return english
+    text = _load_catalog(lang).gettext(english)
+    prefix = _url_prefix.get()
+    if prefix and '](/documentation' in text:
+        text = text.replace('](/documentation', f']({prefix}/documentation')
+    return text

--- a/website/main_page.py
+++ b/website/main_page.py
@@ -5,6 +5,7 @@ from nicegui import ui
 
 from . import documentation, example_card, svg
 from .examples import examples
+from .i18n import get_url_prefix, t
 from .style import example_link, features, heading, link_target, section_heading, subtitle, title
 
 SPONSORS = json.loads((Path(__file__).parent / 'sponsors.json').read_text(encoding='utf-8'))
@@ -12,11 +13,13 @@ SPONSORS = json.loads((Path(__file__).parent / 'sponsors.json').read_text(encodi
 
 def create() -> None:
     """Create the content of the main page."""
+    prefix = get_url_prefix()
+
     with ui.row().classes('w-full h-screen max-h-[200vw] items-center gap-8 pr-4 no-wrap into-section'):
         svg.face(half=True).classes('stroke-black dark:stroke-white w-[200px] md:w-[230px] lg:w-[300px]')
         with ui.column().classes('gap-4 md:gap-8 pt-32'):
-            title('Meet the *NiceGUI*.')
-            subtitle('And let any browser be the frontend of your Python code.') \
+            title(t('Meet the *NiceGUI*.'))
+            subtitle(t('And let any browser be the frontend of your Python code.')) \
                 .classes('max-w-[20rem] sm:max-w-[24rem] md:max-w-[30rem]')
             ui.link(target='#about').classes('scroll-indicator')
 
@@ -28,32 +31,32 @@ def create() -> None:
         '''):
         link_target('about', '70px')
         with ui.column().classes('text-white max-w-4xl'):
-            heading('Interact with Python through buttons, dialogs, 3D&nbsp;scenes, plots and much more.')
+            heading(t('Interact with Python through buttons, dialogs, 3D&nbsp;scenes, plots and much more.'))
             with ui.column().classes('gap-2 bold-links arrow-links text-lg'):
-                ui.markdown('''
-                    NiceGUI manages web development details, letting you focus on Python code for diverse applications,
-                    including robotics, IoT solutions, smart home automation, and machine learning.
-                    Designed to work smoothly with connected peripherals like webcams and GPIO pins in IoT setups,
-                    NiceGUI streamlines the management of all your code in one place.
-                    <br><br>
-                    With a gentle learning curve, NiceGUI is user-friendly for beginners
-                    and offers advanced customization for experienced users,
-                    ensuring simplicity for basic tasks and feasibility for complex projects.
-                    <br><br><br>
-                    Available as
-                    [PyPI package](https://pypi.org/project/nicegui/),
-                    [Docker image](https://hub.docker.com/r/zauberzeug/nicegui) and on
-                    [GitHub](https://github.com/zauberzeug/nicegui).
-                ''')
+                ui.markdown(t(
+                    'NiceGUI manages web development details, letting you focus on Python code for diverse applications,\n'
+                    'including robotics, IoT solutions, smart home automation, and machine learning.\n'
+                    'Designed to work smoothly with connected peripherals like webcams and GPIO pins in IoT setups,\n'
+                    'NiceGUI streamlines the management of all your code in one place.\n'
+                    '<br><br>\n'
+                    'With a gentle learning curve, NiceGUI is user-friendly for beginners\n'
+                    'and offers advanced customization for experienced users,\n'
+                    'ensuring simplicity for basic tasks and feasibility for complex projects.\n'
+                    '<br><br><br>\n'
+                    'Available as\n'
+                    '[PyPI package](https://pypi.org/project/nicegui/),\n'
+                    '[Docker image](https://hub.docker.com/r/zauberzeug/nicegui) and on\n'
+                    '[GitHub](https://github.com/zauberzeug/nicegui).'
+                ))
         example_card.create()
 
     with ui.column().classes('w-full text-lg p-8 lg:p-16 max-w-[1600px] mx-auto'):
         link_target('installation')
-        section_heading('Installation', 'Get *started*')
+        section_heading(t('Installation'), t('Get *started*'))
         with ui.row().classes('w-full text-lg leading-tight grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-8'):
             with ui.column().classes('w-full max-w-md gap-2'):
                 ui.html('<em>1.</em>', sanitize=False).classes('text-3xl font-bold fancy-em')
-                ui.markdown('Create __main.py__').classes('text-lg')
+                ui.markdown(t('Create __main.py__')).classes('text-lg')
                 with documentation.python_window(classes='w-full h-52'):
                     ui.markdown('''
                         ```python\n
@@ -66,7 +69,7 @@ def create() -> None:
                     ''')
             with ui.column().classes('w-full max-w-md gap-2'):
                 ui.html('<em>2.</em>', sanitize=False).classes('text-3xl font-bold fancy-em')
-                ui.markdown('Install and launch').classes('text-lg')
+                ui.markdown(t('Install and launch')).classes('text-lg')
                 with documentation.bash_window(classes='w-full h-52'):
                     ui.markdown('''
                         ```bash
@@ -76,17 +79,17 @@ def create() -> None:
                     ''')
             with ui.column().classes('w-full max-w-md gap-2'):
                 ui.html('<em>3.</em>', sanitize=False).classes('text-3xl font-bold fancy-em')
-                ui.markdown('Enjoy!').classes('text-lg')
+                ui.markdown(t('Enjoy!')).classes('text-lg')
                 with documentation.browser_window(classes='w-full h-52'):
                     ui.label('Hello NiceGUI!')
-        with ui.expansion('...or use Docker to run your main.py').classes('w-full gap-2 bold-links arrow-links'):
+        with ui.expansion(t('...or use Docker to run your main.py')).classes('w-full gap-2 bold-links arrow-links'):
             with ui.row().classes('mt-8 w-full justify-center items-center gap-8'):
-                ui.markdown('''
-                    With our [multi-arch Docker image](https://hub.docker.com/repository/docker/zauberzeug/nicegui)
-                    you can start the server without installing any packages.
-
-                    The command searches for `main.py` in in your current directory and makes the app available at http://localhost:8888.
-                ''').classes('max-w-xl')
+                ui.markdown(t(
+                    'With our [multi-arch Docker image](https://hub.docker.com/repository/docker/zauberzeug/nicegui)\n'
+                    'you can start the server without installing any packages.\n'
+                    '\n'
+                    'The command searches for `main.py` in in your current directory and makes the app available at http://localhost:8888.'
+                )).classes('max-w-xl')
                 with documentation.bash_window(classes='max-w-lg w-full h-52'):
                     ui.markdown('''
                         ```bash
@@ -97,64 +100,64 @@ def create() -> None:
 
     with ui.column().classes('w-full p-8 lg:p-16 bold-links arrow-links max-w-[1600px] mx-auto'):
         link_target('features')
-        section_heading('Features', 'Code *nicely*')
+        section_heading(t('Features'), t('Code *nicely*'))
         with ui.row().classes('w-full text-lg leading-tight grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-8'):
-            features('swap_horiz', 'Interaction', [
-                '[buttons, switches, sliders, inputs, ...](/documentation/section_controls)',
-                '[notifications, dialogs and menus](/documentation/section_page_layout)',
-                '[interactive images](/documentation/interactive_image) with SVG overlays',
-                'web pages and [native window apps](/documentation/section_configuration_deployment#native_mode)',
+            features('swap_horiz', t('Interaction'), [
+                t('[buttons, switches, sliders, inputs, ...](/documentation/section_controls)'),
+                t('[notifications, dialogs and menus](/documentation/section_page_layout)'),
+                t('[interactive images](/documentation/interactive_image) with SVG overlays'),
+                t('web pages and [native window apps](/documentation/section_configuration_deployment#native_mode)'),
             ])
-            features('space_dashboard', 'Layout', [
-                '[navigation bars, tabs, panels, ...](/documentation/section_page_layout)',
-                'grouping with rows, columns, grids and cards',
-                '[HTML](/documentation/html) and [Markdown](/documentation/markdown) elements',
-                'flex layout by default',
+            features('space_dashboard', t('Layout'), [
+                t('[navigation bars, tabs, panels, ...](/documentation/section_page_layout)'),
+                t('grouping with rows, columns, grids and cards'),
+                t('[HTML](/documentation/html) and [Markdown](/documentation/markdown) elements'),
+                t('flex layout by default'),
             ])
-            features('insights', 'Visualization', [
-                '[charts, diagrams, tables](/documentation/section_data_elements), [audio/video](/documentation/section_audiovisual_elements)',
-                '[3D scenes](/documentation/scene)',
-                'straight-forward [data binding](/documentation/section_binding_properties)',
-                'built-in [timer for data refresh](/documentation/timer)',
+            features('insights', t('Visualization'), [
+                t('[charts, diagrams, tables](/documentation/section_data_elements), [audio/video](/documentation/section_audiovisual_elements)'),
+                t('[3D scenes](/documentation/scene)'),
+                t('straight-forward [data binding](/documentation/section_binding_properties)'),
+                t('built-in [timer for data refresh](/documentation/timer)'),
             ])
-            features('brush', 'Styling', [
-                'customizable [color themes](/documentation/section_styling_appearance#color_theming)',
-                'custom CSS and classes',
-                'modern look with material design',
-                '[Tailwind CSS](https://tailwindcss.com/)',
+            features('brush', t('Styling'), [
+                t('customizable [color themes](/documentation/section_styling_appearance#color_theming)'),
+                t('custom CSS and classes'),
+                t('modern look with material design'),
+                t('[Tailwind CSS](https://tailwindcss.com/)'),
             ])
-            features('source', 'Coding', [
-                'single page apps with [ui.sub_pages](/documentation/sub_pages)',
-                'auto-reload on code change',
-                'persistent [user sessions](/documentation/storage)',
-                'super powerful [testing framework](/documentation/section_testing)',
+            features('source', t('Coding'), [
+                t('single page apps with [ui.sub_pages](/documentation/sub_pages)'),
+                t('auto-reload on code change'),
+                t('persistent [user sessions](/documentation/storage)'),
+                t('super powerful [testing framework](/documentation/section_testing)'),
             ])
-            features('anchor', 'Foundation', [
-                'generic [Vue](https://vuejs.org/) to Python bridge',
-                'dynamic GUI through [Quasar](https://quasar.dev/)',
-                'content is served with [FastAPI](https://fastapi.tiangolo.com/)',
-                'Python 3.10+',
+            features('anchor', t('Foundation'), [
+                t('generic [Vue](https://vuejs.org/) to Python bridge'),
+                t('dynamic GUI through [Quasar](https://quasar.dev/)'),
+                t('content is served with [FastAPI](https://fastapi.tiangolo.com/)'),
+                t('Python 3.10+'),
             ])
 
     with ui.column().classes('w-full p-8 lg:p-16 max-w-[1600px] mx-auto'):
         link_target('demos')
-        section_heading('Demos', 'Try *this*')
+        section_heading(t('Demos'), t('Try *this*'))
         with ui.column().classes('w-full'):
             documentation.create_intro()
 
     with ui.column().classes('dark-box p-8 lg:p-16 my-16'):
         with ui.column().classes('mx-auto items-center gap-y-8 gap-x-32 lg:flex-row'):
             with ui.column().classes('gap-1 max-lg:items-center max-lg:text-center'):
-                ui.markdown('Browse through plenty of live demos.') \
+                ui.markdown(t('Browse through plenty of live demos.')) \
                     .classes('text-white text-2xl md:text-3xl font-medium')
-                ui.label('Fun-Fact: This whole website is also coded with NiceGUI.') \
+                ui.label(t('Fun-Fact: This whole website is also coded with NiceGUI.')) \
                     .classes('text-white text-lg md:text-xl')
-            ui.link('Documentation', '/documentation').style('color: black !important') \
+            ui.link(t('Documentation'), f'{prefix}/documentation').style('color: black !important') \
                 .classes('rounded-full mx-auto px-12 py-2 bg-white font-medium text-lg md:text-xl')
 
     with ui.column().classes('w-full p-8 lg:p-16 max-w-[1600px] mx-auto'):
         link_target('examples')
-        section_heading('In-depth examples', 'Pick your *solution*')
+        section_heading(t('In-depth examples'), t('Pick your *solution*'))
         with ui.row().classes('w-full text-lg leading-tight grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4'):
             for example in examples:
                 if example.title in {'Authentication', 'Chat App', 'Todo List'}:
@@ -165,7 +168,7 @@ def create() -> None:
         with ui.column().classes('mx-auto items-center gap-y-8 gap-x-32 lg:flex-row'):
             with ui.column().classes('max-lg:items-center max-lg:text-center gap-8'):
                 link_target('sponsors')
-                ui.markdown('NiceGUI is supported by') \
+                ui.markdown(t('NiceGUI is supported by')) \
                     .classes('text-2xl md:text-3xl font-medium')
                 if SPONSORS['special'] or SPONSORS['top']:
                     with ui.row().classes('gap-8 justify-center'):
@@ -196,7 +199,7 @@ def create() -> None:
                     .classes('rounded-full mx-auto px-12 py-2 border-2 border-[#3e6a94] font-medium text-lg md:text-xl'):
                 with ui.row(wrap=False).classes('items-center gap-4'):
                     ui.icon('favorite_border', color='#3e6a94')
-                    ui.label('Become a sponsor').classes('text-[#3e6a94] whitespace-nowrap')
+                    ui.label(t('Become a sponsor')).classes('text-[#3e6a94] whitespace-nowrap')
 
     with ui.row().classes('dark-box min-h-screen mt-16'):
         link_target('why', '70px')
@@ -206,34 +209,34 @@ def create() -> None:
                 items-center justify-center no-wrap flex-col md:flex-row gap-16
             '''):
             with ui.column().classes('gap-8'):
-                heading('Why?')
+                heading(t('Why?'))
                 with ui.column().classes('gap-2 text-xl text-white bold-links arrow-links'):
-                    ui.markdown('''
-                        We at
-                        [Zauberzeug](https://zauberzeug.com)
-                        like
-                        [Streamlit](https://streamlit.io/)
-                        but find it does
-                        [too much magic](https://github.com/zauberzeug/nicegui/issues/1#issuecomment-847413651)
-                        when it comes to state handling.
-                        In search for an alternative nice library to write simple graphical user interfaces in Python we discovered
-                        [JustPy](https://justpy.io/).
-                        Although we liked the approach, it is too "low-level HTML" for our daily usage.
-                        But it inspired us to use
-                        [Vue](https://vuejs.org/)
-                        and
-                        [Quasar](https://quasar.dev/)
-                        for the frontend.
-                    ''')
-                    ui.markdown('''
-                        We have built on top of
-                        [FastAPI](https://fastapi.tiangolo.com/),
-                        which itself is based on the ASGI framework
-                        [Starlette](https://www.starlette.io/)
-                        and the ASGI webserver
-                        [Uvicorn](https://www.uvicorn.org/)
-                        because of their great performance and ease of use.
-                    ''')
+                    ui.markdown(t(
+                        'We at\n'
+                        '[Zauberzeug](https://zauberzeug.com)\n'
+                        'like\n'
+                        '[Streamlit](https://streamlit.io/)\n'
+                        'but find it does\n'
+                        '[too much magic](https://github.com/zauberzeug/nicegui/issues/1#issuecomment-847413651)\n'
+                        'when it comes to state handling.\n'
+                        'In search for an alternative nice library to write simple graphical user interfaces in Python we discovered\n'
+                        '[JustPy](https://justpy.io/).\n'
+                        'Although we liked the approach, it is too "low-level HTML" for our daily usage.\n'
+                        'But it inspired us to use\n'
+                        '[Vue](https://vuejs.org/)\n'
+                        'and\n'
+                        '[Quasar](https://quasar.dev/)\n'
+                        'for the frontend.'
+                    ))
+                    ui.markdown(t(
+                        'We have built on top of\n'
+                        '[FastAPI](https://fastapi.tiangolo.com/),\n'
+                        'which itself is based on the ASGI framework\n'
+                        '[Starlette](https://www.starlette.io/)\n'
+                        'and the ASGI webserver\n'
+                        '[Uvicorn](https://www.uvicorn.org/)\n'
+                        'because of their great performance and ease of use.'
+                    ))
             svg.face().classes('stroke-white shrink-0 w-[200px] md:w-[300px] lg:w-[450px]')
         with ui.column().classes('w-full p-4 items-end text-white self-end'):
-            ui.link('Imprint & Privacy', '/imprint_privacy').classes('text-sm')
+            ui.link(t('Imprint & Privacy'), f'{prefix}/imprint_privacy').classes('text-sm')

--- a/website/search.py
+++ b/website/search.py
@@ -2,6 +2,7 @@ from nicegui import __version__, background_tasks, events, ui
 
 from .documentation import CustomRestructuredText as custom_restructured_text
 from .documentation.search import search_index
+from .i18n import t
 
 
 class Search:
@@ -37,7 +38,7 @@ class Search:
         with ui.dialog() as self.dialog, ui.card().tight().classes('w-[800px] h-[600px]'):
             with ui.row().classes('w-full items-center px-4'):
                 ui.icon('search', size='2em')
-                self.input = ui.input(placeholder='Search documentation', on_change=self.handle_input) \
+                self.input = ui.input(placeholder=t('Search documentation'), on_change=self.handle_input) \
                     .classes('flex-grow').props('borderless autofocus')
                 ui.button('ESC', on_click=self.dialog.close) \
                     .props('padding="2px 8px" outline size=sm color=grey-5').classes('shadow')
@@ -53,7 +54,7 @@ class Search:
 
     def create_button(self) -> ui.button:
         return ui.button(on_click=self.open_dialog, icon='search').props('flat color=white') \
-            .tooltip('Press Ctrl+K or / to search the documentation')
+            .tooltip(t('Press Ctrl+K or / to search the documentation'))
 
     def handle_input(self, e: events.ValueChangeEventArguments) -> None:
         async def handle_input() -> None:

--- a/website/star.py
+++ b/website/star.py
@@ -1,6 +1,7 @@
 from nicegui import ui
 from nicegui.element import Element
 from website import svg
+from website.i18n import t
 
 STYLE = '''
     @keyframes star-tumble {
@@ -41,6 +42,6 @@ def add_star() -> ui.link:
             with ui.row().classes('items-center no-wrap'):
                 svg.face().classes('w-14 stroke-white stroke-[1pt]')
                 with ui.column().classes('p-2 gap-2'):
-                    ui.label('Star us on GitHub!').classes('text-[180%]')
-                    ui.label('And tell others about NiceGUI.').classes('text-[140%]')
+                    ui.label(t('Star us on GitHub!')).classes('text-[180%]')
+                    ui.label(t('And tell others about NiceGUI.')).classes('text-[140%]')
     return link

--- a/website/style.py
+++ b/website/style.py
@@ -3,6 +3,7 @@ import re
 from nicegui import ui
 
 from .examples import Example
+from .i18n import get_url_prefix, t
 
 SPECIAL_CHARACTERS = re.compile('[^(a-z)(A-Z)(0-9)-]')
 
@@ -38,11 +39,12 @@ def subtitle(content: str) -> ui.markdown:
 
 def example_link(example: Example | None = None) -> ui.link:
     """Render a link to an example."""
-    with ui.link(target=example.url if example else '/examples') \
+    prefix = get_url_prefix()
+    with ui.link(target=example.url if example else f'{prefix}/examples') \
             .classes('bg-[#5898d420] p-4 self-stretch rounded flex flex-col gap-2') \
             .style('box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1)') as link:
-        ui.label(example.title if example else '...and many more').classes(replace='font-bold')
-        ui.markdown(example.description if example else 'Browse through plenty of examples.') \
+        ui.label(example.title if example else t('...and many more')).classes(replace='font-bold')
+        ui.markdown(example.description if example else t('Browse through plenty of examples.')) \
             .classes(replace='bold-links arrow-links')
         if example:
             ui.space()

--- a/website/translations/de/LC_MESSAGES/messages.po
+++ b/website/translations/de/LC_MESSAGES/messages.po
@@ -1,0 +1,394 @@
+# German translations for PROJECT.
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-02-27 09:15+0000\n"
+"PO-Revision-Date: 2026-02-27 09:29+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: de\n"
+"Language-Team: de <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "In-depth examples"
+msgstr "German translation of: In-depth examples"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "Pick your *solution*"
+msgstr "Wählen Sie Ihre *Lösung*"
+
+#: website/header.py:30 website/main_page.py:55
+msgid "Installation"
+msgstr ""
+
+#: website/header.py:31 website/main_page.py:103
+msgid "Features"
+msgstr "Funktionen"
+
+#: website/header.py:32 website/main_page.py:144
+msgid "Demos"
+msgstr ""
+
+#: website/header.py:33 website/main_page.py:155
+msgid "Documentation"
+msgstr "Dokumentation"
+
+#: website/header.py:34
+msgid "Examples"
+msgstr "Beispiele"
+
+#: website/header.py:35 website/main_page.py:212
+msgid "Why?"
+msgstr "Warum?"
+
+#: website/header.py:59
+msgid "Cycle theme mode through dark, light, and system/auto."
+msgstr "Wechsle den Themenmodus zyklisch durch dunkel, hell und system/auto."
+
+#: website/header.py:67
+msgid "Discord"
+msgstr ""
+
+#: website/header.py:69
+msgid "Reddit"
+msgstr ""
+
+#: website/header.py:71
+msgid "GitHub"
+msgstr ""
+
+#: website/main_page.py:21
+msgid "Meet the *NiceGUI*."
+msgstr "Treffen Sie die *NiceGUI*."
+
+#: website/main_page.py:22
+msgid "And let any browser be the frontend of your Python code."
+msgstr "Und lassen Sie jeden Browser das Frontend Ihres Python-Codes sein."
+
+#: website/main_page.py:34
+msgid ""
+"Interact with Python through buttons, dialogs, 3D&nbsp;scenes, plots and "
+"much more."
+msgstr "Interagieren Sie mit Python über Schaltflächen, Dialoge, 3D&nbsp;Szenen, Diagramme und vieles mehr."
+
+#: website/main_page.py:37
+msgid ""
+"NiceGUI manages web development details, letting you focus on Python code"
+" for diverse applications,\n"
+"including robotics, IoT solutions, smart home automation, and machine "
+"learning.\n"
+"Designed to work smoothly with connected peripherals like webcams and "
+"GPIO pins in IoT setups,\n"
+"NiceGUI streamlines the management of all your code in one place.\n"
+"<br><br>\n"
+"With a gentle learning curve, NiceGUI is user-friendly for beginners\n"
+"and offers advanced customization for experienced users,\n"
+"ensuring simplicity for basic tasks and feasibility for complex projects."
+"\n"
+"<br><br><br>\n"
+"Available as\n"
+"[PyPI package](https://pypi.org/project/nicegui/),\n"
+"[Docker image](https://hub.docker.com/r/zauberzeug/nicegui) and on\n"
+"[GitHub](https://github.com/zauberzeug/nicegui)."
+msgstr ""
+
+#: website/main_page.py:55
+msgid "Get *started*"
+msgstr "*Loslegen*"
+
+#: website/main_page.py:59
+msgid "Create __main.py__"
+msgstr "Erstelle __main.py__"
+
+#: website/main_page.py:72
+msgid "Install and launch"
+msgstr "Installieren und starten"
+
+#: website/main_page.py:82
+msgid "Enjoy!"
+msgstr "Viel Spaß!"
+
+#: website/main_page.py:85
+msgid "...or use Docker to run your main.py"
+msgstr "...oder verwenden Sie Docker, um Ihre main.py auszuführen"
+
+#: website/main_page.py:88
+msgid ""
+"With our [multi-arch Docker "
+"image](https://hub.docker.com/repository/docker/zauberzeug/nicegui)\n"
+"you can start the server without installing any packages.\n"
+"\n"
+"The command searches for `main.py` in in your current directory and makes"
+" the app available at http://localhost:8888."
+msgstr ""
+
+#: website/main_page.py:103
+msgid "Code *nicely*"
+msgstr "Code *sauber*"
+
+#: website/main_page.py:105
+msgid "Interaction"
+msgstr "Interaktion"
+
+#: website/main_page.py:106
+msgid "[buttons, switches, sliders, inputs, ...](/documentation/section_controls)"
+msgstr "[Buttons, Schalter, Slider, Eingaben, ...](/documentation/section_controls)"
+
+#: website/main_page.py:107
+msgid "[notifications, dialogs and menus](/documentation/section_page_layout)"
+msgstr "[Benachrichtigungen, Dialoge und Menüs](/documentation/section_page_layout)"
+
+#: website/main_page.py:108
+msgid "[interactive images](/documentation/interactive_image) with SVG overlays"
+msgstr "[interaktive Bilder](/documentation/interactive_image) mit SVG-Overlays"
+
+#: website/main_page.py:109
+msgid ""
+"web pages and [native window "
+"apps](/documentation/section_configuration_deployment#native_mode)"
+msgstr "Webseiten und [native Fenster-Apps](/documentation/section_configuration_deployment#native_mode)"
+
+#: website/main_page.py:111
+msgid "Layout"
+msgstr ""
+
+#: website/main_page.py:112
+msgid "[navigation bars, tabs, panels, ...](/documentation/section_page_layout)"
+msgstr "[navigationsleisten, Tabs, Panels, ...](/documentation/section_page_layout)"
+
+#: website/main_page.py:113
+msgid "grouping with rows, columns, grids and cards"
+msgstr "Gruppierung mit Zeilen, Spalten, Grids und Karten"
+
+#: website/main_page.py:114
+msgid ""
+"[HTML](/documentation/html) and [Markdown](/documentation/markdown) "
+"elements"
+msgstr "[HTML](/documentation/html) und [Markdown](/documentation/markdown)-Elemente"
+
+#: website/main_page.py:115
+msgid "flex layout by default"
+msgstr "Standardmäßig Flex-Layout"
+
+#: website/main_page.py:117
+msgid "Visualization"
+msgstr "Visualisierung"
+
+#: website/main_page.py:118
+msgid ""
+"[charts, diagrams, tables](/documentation/section_data_elements), "
+"[audio/video](/documentation/section_audiovisual_elements)"
+msgstr "[Diagramme, Grafiken, Tabellen](/documentation/section_data_elements), [Audio/Video](/documentation/section_audiovisual_elements)"
+
+#: website/main_page.py:119
+msgid "[3D scenes](/documentation/scene)"
+msgstr "[3D-Szenen](/documentation/scene)"
+
+#: website/main_page.py:120
+msgid "straight-forward [data binding](/documentation/section_binding_properties)"
+msgstr "einfaches [Datenbindung](/documentation/section_binding_properties)"
+
+#: website/main_page.py:121
+msgid "built-in [timer for data refresh](/documentation/timer)"
+msgstr "eingebauter [Timer zur Datenaktualisierung](/documentation/timer)"
+
+#: website/main_page.py:123
+msgid "Styling"
+msgstr ""
+
+#: website/main_page.py:124
+msgid ""
+"customizable [color "
+"themes](/documentation/section_styling_appearance#color_theming)"
+msgstr "anpassbare [Farbschemata](/documentation/section_styling_appearance#color_theming)"
+
+#: website/main_page.py:125
+msgid "custom CSS and classes"
+msgstr "benutzerdefiniertes CSS und Klassen"
+
+#: website/main_page.py:126
+msgid "modern look with material design"
+msgstr "moderner Look mit Material Design"
+
+#: website/main_page.py:127
+msgid "[Tailwind CSS](https://tailwindcss.com/)"
+msgstr ""
+
+#: website/main_page.py:129
+msgid "Coding"
+msgstr "Programmierung"
+
+#: website/main_page.py:130
+msgid "single page apps with [ui.sub_pages](/documentation/sub_pages)"
+msgstr "Single-Page-Apps mit [ui.sub_pages](/documentation/sub_pages)"
+
+#: website/main_page.py:131
+msgid "auto-reload on code change"
+msgstr "Automatisches Neuladen bei Codeänderung"
+
+#: website/main_page.py:132
+msgid "persistent [user sessions](/documentation/storage)"
+msgstr "persistente [Benutzersitzungen](/documentation/storage)"
+
+#: website/main_page.py:133
+msgid "super powerful [testing framework](/documentation/section_testing)"
+msgstr "super leistungsstarkes [Test-Framework](/documentation/section_testing)"
+
+#: website/main_page.py:135
+msgid "Foundation"
+msgstr "Grundlage"
+
+#: website/main_page.py:136
+msgid "generic [Vue](https://vuejs.org/) to Python bridge"
+msgstr "generische [Vue](https://vuejs.org/)-zu-Python-Brücke"
+
+#: website/main_page.py:137
+msgid "dynamic GUI through [Quasar](https://quasar.dev/)"
+msgstr "dynamische GUI durch [Quasar](https://quasar.dev/)"
+
+#: website/main_page.py:138
+msgid "content is served with [FastAPI](https://fastapi.tiangolo.com/)"
+msgstr "Inhalte werden mit [FastAPI](https://fastapi.tiangolo.com/) bereitgestellt"
+
+#: website/main_page.py:139
+msgid "Python 3.10+"
+msgstr ""
+
+#: website/main_page.py:144
+msgid "Try *this*"
+msgstr "Probieren Sie *dieses* aus"
+
+#: website/main_page.py:151
+msgid "Browse through plenty of live demos."
+msgstr "Durchsuchen Sie zahlreiche Live-Demos."
+
+#: website/main_page.py:153
+msgid "Fun-Fact: This whole website is also coded with NiceGUI."
+msgstr "Fun-Fact: Diese ganze Website ist ebenfalls mit NiceGUI programmiert."
+
+#: website/main_page.py:171
+msgid "NiceGUI is supported by"
+msgstr "NiceGUI wird unterstützt von"
+
+#: website/main_page.py:202
+msgid "Become a sponsor"
+msgstr "Werden Sie Sponsor"
+
+#: website/main_page.py:215
+msgid ""
+"We at\n"
+"[Zauberzeug](https://zauberzeug.com)\n"
+"like\n"
+"[Streamlit](https://streamlit.io/)\n"
+"but find it does\n"
+"[too much "
+"magic](https://github.com/zauberzeug/nicegui/issues/1#issuecomment-847413651)"
+"\n"
+"when it comes to state handling.\n"
+"In search for an alternative nice library to write simple graphical user "
+"interfaces in Python we discovered\n"
+"[JustPy](https://justpy.io/).\n"
+"Although we liked the approach, it is too \"low-level HTML\" for our "
+"daily usage.\n"
+"But it inspired us to use\n"
+"[Vue](https://vuejs.org/)\n"
+"and\n"
+"[Quasar](https://quasar.dev/)\n"
+"for the frontend."
+msgstr ""
+
+#: website/main_page.py:232
+msgid ""
+"We have built on top of\n"
+"[FastAPI](https://fastapi.tiangolo.com/),\n"
+"which itself is based on the ASGI framework\n"
+"[Starlette](https://www.starlette.io/)\n"
+"and the ASGI webserver\n"
+"[Uvicorn](https://www.uvicorn.org/)\n"
+"because of their great performance and ease of use."
+msgstr ""
+
+#: website/main_page.py:242
+msgid "Imprint & Privacy"
+msgstr "German translation of: Imprint & Privacy"
+
+#: website/search.py:41
+msgid "Search documentation"
+msgstr "Dokumentation durchsuchen"
+
+#: website/search.py:57
+msgid "Press Ctrl+K or / to search the documentation"
+msgstr "Drücken Sie Strg+K oder /, um die Dokumentation zu durchsuchen"
+
+#: website/star.py:45
+msgid "Star us on GitHub!"
+msgstr "Gib uns einen Stern auf GitHub!"
+
+#: website/star.py:46
+msgid "And tell others about NiceGUI."
+msgstr "Und erzählen Sie anderen von NiceGUI."
+
+#: website/style.py:46
+msgid "...and many more"
+msgstr "...und viele mehr"
+
+#: website/style.py:47
+msgid "Browse through plenty of examples."
+msgstr "Durchsuchen Sie zahlreiche Beispiele."
+
+#: website/documentation/intro.py:13
+msgid "Single-Page Applications"
+msgstr "Single-Page-Anwendungen"
+
+#: website/documentation/intro.py:14
+msgid ""
+"Build applications with fast client-side routing using "
+"[`ui.sub_pages`](/documentation/sub_pages)\n"
+"and a `root` function as single entry point.\n"
+"For each visitor, the `root` function is executed and generates the "
+"interface.\n"
+"[`ui.link`](/documentation/link) and "
+"[`ui.navigate`](/documentation/navigate) can be used to navigate to other"
+" sub pages.\n"
+"\n"
+"If you do not want a single-page application, you can also use "
+"[`@ui.page('/your/path')`](/documentation/page)\n"
+"to define standalone content available at a specific path."
+msgstr ""
+
+#: website/documentation/intro.py:50
+msgid "Reactive Transformations"
+msgstr "Reaktive Transformationen"
+
+#: website/documentation/intro.py:51
+msgid ""
+"Create real-time interfaces with automatic updates.\n"
+"Type and watch text flow in both directions.\n"
+"When input changes, the "
+"[binding](/documentation/section_binding_properties) transforms the text"
+"\n"
+"with a custom Python function and updates the label."
+msgstr ""
+
+#: website/documentation/intro.py:66
+msgid "Event System"
+msgstr "Ereignissystem"
+
+#: website/documentation/intro.py:67
+msgid ""
+"Use an [Event](/documentation/event) to trigger actions and pass data.\n"
+"Here we have an IoT temperature sensor submitting its readings\n"
+"to a [FastAPI "
+"endpoint](/documentation/section_pages_routing#api_responses) with path "
+"\"/sensor\".\n"
+"When a new value arrives, it emits an event for the chart to be updated."
+msgstr ""

--- a/website/translations/ja/LC_MESSAGES/messages.po
+++ b/website/translations/ja/LC_MESSAGES/messages.po
@@ -1,0 +1,394 @@
+# Japanese translations for PROJECT.
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-02-27 09:15+0000\n"
+"PO-Revision-Date: 2026-02-27 09:29+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "In-depth examples"
+msgstr "詳細な例"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "Pick your *solution*"
+msgstr "選択してください *ソリューション*"
+
+#: website/header.py:30 website/main_page.py:55
+msgid "Installation"
+msgstr "インストレーション"
+
+#: website/header.py:31 website/main_page.py:103
+msgid "Features"
+msgstr "特徴"
+
+#: website/header.py:32 website/main_page.py:144
+msgid "Demos"
+msgstr "デモ"
+
+#: website/header.py:33 website/main_page.py:155
+msgid "Documentation"
+msgstr "ドキュメント"
+
+#: website/header.py:34
+msgid "Examples"
+msgstr "例示"
+
+#: website/header.py:35 website/main_page.py:212
+msgid "Why?"
+msgstr "なぜ？"
+
+#: website/header.py:59
+msgid "Cycle theme mode through dark, light, and system/auto."
+msgstr "サイクルテーマモードをダーク、ライト、システム/自動で切り替えます。"
+
+#: website/header.py:67
+msgid "Discord"
+msgstr ""
+
+#: website/header.py:69
+msgid "Reddit"
+msgstr ""
+
+#: website/header.py:71
+msgid "GitHub"
+msgstr ""
+
+#: website/main_page.py:21
+msgid "Meet the *NiceGUI*."
+msgstr "*NiceGUI* をご覧ください。"
+
+#: website/main_page.py:22
+msgid "And let any browser be the frontend of your Python code."
+msgstr "Python コードのフロントエンドを任意のブラウザーにしましょう。"
+
+#: website/main_page.py:34
+msgid ""
+"Interact with Python through buttons, dialogs, 3D&nbsp;scenes, plots and "
+"much more."
+msgstr "インタラクトするには、ボタン、ダイアログ、3Dシーン、グラフなどを通じてPythonとやり取りできます。"
+
+#: website/main_page.py:37
+msgid ""
+"NiceGUI manages web development details, letting you focus on Python code"
+" for diverse applications,\n"
+"including robotics, IoT solutions, smart home automation, and machine "
+"learning.\n"
+"Designed to work smoothly with connected peripherals like webcams and "
+"GPIO pins in IoT setups,\n"
+"NiceGUI streamlines the management of all your code in one place.\n"
+"<br><br>\n"
+"With a gentle learning curve, NiceGUI is user-friendly for beginners\n"
+"and offers advanced customization for experienced users,\n"
+"ensuring simplicity for basic tasks and feasibility for complex projects."
+"\n"
+"<br><br><br>\n"
+"Available as\n"
+"[PyPI package](https://pypi.org/project/nicegui/),\n"
+"[Docker image](https://hub.docker.com/r/zauberzeug/nicegui) and on\n"
+"[GitHub](https://github.com/zauberzeug/nicegui)."
+msgstr ""
+
+#: website/main_page.py:55
+msgid "Get *started*"
+msgstr ""
+
+#: website/main_page.py:59
+msgid "Create __main.py__"
+msgstr ""
+
+#: website/main_page.py:72
+msgid "Install and launch"
+msgstr "インストールと起動"
+
+#: website/main_page.py:82
+msgid "Enjoy!"
+msgstr "楽しんで！"
+
+#: website/main_page.py:85
+msgid "...or use Docker to run your main.py"
+msgstr "…または、Dockerを使用してmain.pyを実行してください。"
+
+#: website/main_page.py:88
+msgid ""
+"With our [multi-arch Docker "
+"image](https://hub.docker.com/repository/docker/zauberzeug/nicegui)\n"
+"you can start the server without installing any packages.\n"
+"\n"
+"The command searches for `main.py` in in your current directory and makes"
+" the app available at http://localhost:8888."
+msgstr ""
+
+#: website/main_page.py:103
+msgid "Code *nicely*"
+msgstr "綺麗にコード"
+
+#: website/main_page.py:105
+msgid "Interaction"
+msgstr "相互作用"
+
+#: website/main_page.py:106
+msgid "[buttons, switches, sliders, inputs, ...](/documentation/section_controls)"
+msgstr "[ボタン、スライダー、入力…](/documentation/section_controls)"
+
+#: website/main_page.py:107
+msgid "[notifications, dialogs and menus](/documentation/section_page_layout)"
+msgstr "[通知、ダイアログおよびメニュー](/documentation/section_page_layout)"
+
+#: website/main_page.py:108
+msgid "[interactive images](/documentation/interactive_image) with SVG overlays"
+msgstr "[インタラクティブな画像](/documentation/interactive_image) に SVG オーバーレイを追加"
+
+#: website/main_page.py:109
+msgid ""
+"web pages and [native window "
+"apps](/documentation/section_configuration_deployment#native_mode)"
+msgstr "web pages および [ネイティブウィンドウアプリ](/documentation/section_configuration_deployment#native_mode)"
+
+#: website/main_page.py:111
+msgid "Layout"
+msgstr "レイアウト"
+
+#: website/main_page.py:112
+msgid "[navigation bars, tabs, panels, ...](/documentation/section_page_layout)"
+msgstr "[ナビゲーションバー、タブ、パネル…](/documentation/section_page_layout)"
+
+#: website/main_page.py:113
+msgid "grouping with rows, columns, grids and cards"
+msgstr "行、列、グリッド、カードを使用したグループ化レイアウト"
+
+#: website/main_page.py:114
+msgid ""
+"[HTML](/documentation/html) and [Markdown](/documentation/markdown) "
+"elements"
+msgstr "[HTML](/documentation/html) と [Markdown](/documentation/markdown) 要素"
+
+#: website/main_page.py:115
+msgid "flex layout by default"
+msgstr "デフォルトではフレキシブルレイアウト。"
+
+#: website/main_page.py:117
+msgid "Visualization"
+msgstr "可視化"
+
+#: website/main_page.py:118
+msgid ""
+"[charts, diagrams, tables](/documentation/section_data_elements), "
+"[audio/video](/documentation/section_audiovisual_elements)"
+msgstr "[グラフ、図表、テーブル](/documentation/section_data_elements), [オーディオ/ビデオ](/documentation/section_audiovisual_elements)"
+
+#: website/main_page.py:119
+msgid "[3D scenes](/documentation/scene)"
+msgstr "[3Dシーン](/documentation/scene)"
+
+#: website/main_page.py:120
+msgid "straight-forward [data binding](/documentation/section_binding_properties)"
+msgstr "直感的な [データバインディング](/documentation/section_binding_properties)"
+
+#: website/main_page.py:121
+msgid "built-in [timer for data refresh](/documentation/timer)"
+msgstr "[データ更新用のタイマー](/documentation/timer) が組み込まれている。"
+
+#: website/main_page.py:123
+msgid "Styling"
+msgstr "スタイル"
+
+#: website/main_page.py:124
+msgid ""
+"customizable [color "
+"themes](/documentation/section_styling_appearance#color_theming)"
+msgstr "[カラーテーマ](/documentation/section_styling_appearance#color_theming) のカスタマイズ"
+
+#: website/main_page.py:125
+msgid "custom CSS and classes"
+msgstr "custom CSSおよびクラス"
+
+#: website/main_page.py:126
+msgid "modern look with material design"
+msgstr "モダンなルックとマテリアルデザイン"
+
+#: website/main_page.py:127
+msgid "[Tailwind CSS](https://tailwindcss.com/)"
+msgstr ""
+
+#: website/main_page.py:129
+msgid "Coding"
+msgstr "コーディング"
+
+#: website/main_page.py:130
+msgid "single page apps with [ui.sub_pages](/documentation/sub_pages)"
+msgstr "シングルページアプリケーションを [ui.sub_pages](/documentation/sub_pages) で作成する"
+
+#: website/main_page.py:131
+msgid "auto-reload on code change"
+msgstr "コード変更時に自動再読み込み"
+
+#: website/main_page.py:132
+msgid "persistent [user sessions](/documentation/storage)"
+msgstr "永続化された [ユーザーセッション](/documentation/storage)"
+
+#: website/main_page.py:133
+msgid "super powerful [testing framework](/documentation/section_testing)"
+msgstr "超強力な[テストフレームワーク](/documentation/section_testing)"
+
+#: website/main_page.py:135
+msgid "Foundation"
+msgstr ""
+
+#: website/main_page.py:136
+msgid "generic [Vue](https://vuejs.org/) to Python bridge"
+msgstr "generic [Vue](https://vuejs.org/) to Python ブリッジ"
+
+#: website/main_page.py:137
+msgid "dynamic GUI through [Quasar](https://quasar.dev/)"
+msgstr "動的なGUIを[Quasar](https://quasar.dev/)を使用することで実現"
+
+#: website/main_page.py:138
+msgid "content is served with [FastAPI](https://fastapi.tiangolo.com/)"
+msgstr "コンテンツは[FastAPI](https://fastapi.tiangolo.com/)で提供されます。"
+
+#: website/main_page.py:139
+msgid "Python 3.10+"
+msgstr ""
+
+#: website/main_page.py:144
+msgid "Try *this*"
+msgstr "こちらを試してみてください"
+
+#: website/main_page.py:151
+msgid "Browse through plenty of live demos."
+msgstr "たくさんのライブデモを閲覧してください。"
+
+#: website/main_page.py:153
+msgid "Fun-Fact: This whole website is also coded with NiceGUI."
+msgstr "面白い事実：このウェブサイト全体は、NiceGUIでコーディングされています。"
+
+#: website/main_page.py:171
+msgid "NiceGUI is supported by"
+msgstr "NiceGUIはサポートされています。"
+
+#: website/main_page.py:202
+msgid "Become a sponsor"
+msgstr "スポンサーになる"
+
+#: website/main_page.py:215
+msgid ""
+"We at\n"
+"[Zauberzeug](https://zauberzeug.com)\n"
+"like\n"
+"[Streamlit](https://streamlit.io/)\n"
+"but find it does\n"
+"[too much "
+"magic](https://github.com/zauberzeug/nicegui/issues/1#issuecomment-847413651)"
+"\n"
+"when it comes to state handling.\n"
+"In search for an alternative nice library to write simple graphical user "
+"interfaces in Python we discovered\n"
+"[JustPy](https://justpy.io/).\n"
+"Although we liked the approach, it is too \"low-level HTML\" for our "
+"daily usage.\n"
+"But it inspired us to use\n"
+"[Vue](https://vuejs.org/)\n"
+"and\n"
+"[Quasar](https://quasar.dev/)\n"
+"for the frontend."
+msgstr ""
+
+#: website/main_page.py:232
+msgid ""
+"We have built on top of\n"
+"[FastAPI](https://fastapi.tiangolo.com/),\n"
+"which itself is based on the ASGI framework\n"
+"[Starlette](https://www.starlette.io/)\n"
+"and the ASGI webserver\n"
+"[Uvicorn](https://www.uvicorn.org/)\n"
+"because of their great performance and ease of use."
+msgstr ""
+
+#: website/main_page.py:242
+msgid "Imprint & Privacy"
+msgstr "判子とプライバシー"
+
+#: website/search.py:41
+msgid "Search documentation"
+msgstr "検索ドキュメント"
+
+#: website/search.py:57
+msgid "Press Ctrl+K or / to search the documentation"
+msgstr "Ctrl+K または / でドキュメントを検索してください。"
+
+#: website/star.py:45
+msgid "Star us on GitHub!"
+msgstr "スターをGitHubでお願いします！"
+
+#: website/star.py:46
+msgid "And tell others about NiceGUI."
+msgstr "NiceGUI について他の人に知らせましょう。"
+
+#: website/style.py:46
+msgid "...and many more"
+msgstr "…そして、さらにたくさん。"
+
+#: website/style.py:47
+msgid "Browse through plenty of examples."
+msgstr "たくさんある例を閲覧してください。"
+
+#: website/documentation/intro.py:13
+msgid "Single-Page Applications"
+msgstr "シングルページアプリケーション"
+
+#: website/documentation/intro.py:14
+msgid ""
+"Build applications with fast client-side routing using "
+"[`ui.sub_pages`](/documentation/sub_pages)\n"
+"and a `root` function as single entry point.\n"
+"For each visitor, the `root` function is executed and generates the "
+"interface.\n"
+"[`ui.link`](/documentation/link) and "
+"[`ui.navigate`](/documentation/navigate) can be used to navigate to other"
+" sub pages.\n"
+"\n"
+"If you do not want a single-page application, you can also use "
+"[`@ui.page('/your/path')`](/documentation/page)\n"
+"to define standalone content available at a specific path."
+msgstr ""
+
+#: website/documentation/intro.py:50
+msgid "Reactive Transformations"
+msgstr "反応型変換"
+
+#: website/documentation/intro.py:51
+msgid ""
+"Create real-time interfaces with automatic updates.\n"
+"Type and watch text flow in both directions.\n"
+"When input changes, the "
+"[binding](/documentation/section_binding_properties) transforms the text"
+"\n"
+"with a custom Python function and updates the label."
+msgstr ""
+
+#: website/documentation/intro.py:66
+msgid "Event System"
+msgstr "イベントシステム"
+
+#: website/documentation/intro.py:67
+msgid ""
+"Use an [Event](/documentation/event) to trigger actions and pass data.\n"
+"Here we have an IoT temperature sensor submitting its readings\n"
+"to a [FastAPI "
+"endpoint](/documentation/section_pages_routing#api_responses) with path "
+"\"/sensor\".\n"
+"When a new value arrives, it emits an event for the chart to be updated."
+msgstr ""

--- a/website/translations/ko/LC_MESSAGES/messages.po
+++ b/website/translations/ko/LC_MESSAGES/messages.po
@@ -1,0 +1,397 @@
+# Korean translations for PROJECT.
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-02-27 09:15+0000\n"
+"PO-Revision-Date: 2026-02-27 09:29+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ko\n"
+"Language-Team: ko <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "In-depth examples"
+msgstr "상세 예제"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "Pick your *solution*"
+msgstr "당신의 *해결책*을 선택하세요"
+
+#: website/header.py:30 website/main_page.py:55
+msgid "Installation"
+msgstr "설치"
+
+#: website/header.py:31 website/main_page.py:103
+msgid "Features"
+msgstr "기능 특성"
+
+#: website/header.py:32 website/main_page.py:144
+msgid "Demos"
+msgstr "데모"
+
+#: website/header.py:33 website/main_page.py:155
+msgid "Documentation"
+msgstr "문서"
+
+#: website/header.py:34
+msgid "Examples"
+msgstr "예제"
+
+#: website/header.py:35 website/main_page.py:212
+msgid "Why?"
+msgstr "왜인가요?"
+
+#: website/header.py:59
+msgid "Cycle theme mode through dark, light, and system/auto."
+msgstr "주제를 어두운, 밝은, 시스템/자동 모드 사이에서 전환합니다."
+
+#: website/header.py:67
+msgid "Discord"
+msgstr ""
+
+#: website/header.py:69
+msgid "Reddit"
+msgstr ""
+
+#: website/header.py:71
+msgid "GitHub"
+msgstr ""
+
+#: website/main_page.py:21
+msgid "Meet the *NiceGUI*."
+msgstr "*NiceGUI*를 만나셨습니다."
+
+#: website/main_page.py:22
+msgid "And let any browser be the frontend of your Python code."
+msgstr "Python 코드의 프론트엔드 인터랙션 인터페이스로 임의의 브라우저를 사용할 수 있습니다."
+
+#: website/main_page.py:34
+msgid ""
+"Interact with Python through buttons, dialogs, 3D&nbsp;scenes, plots and "
+"much more."
+msgstr "버튼, 대화창, 3D 장면, 플롯 등 다양한 컴포넌트를 통해 Python 코드와 실시간으로 상호작용할 수 있습니다."
+
+#: website/main_page.py:37
+msgid ""
+"NiceGUI manages web development details, letting you focus on Python code"
+" for diverse applications,\n"
+"including robotics, IoT solutions, smart home automation, and machine "
+"learning.\n"
+"Designed to work smoothly with connected peripherals like webcams and "
+"GPIO pins in IoT setups,\n"
+"NiceGUI streamlines the management of all your code in one place.\n"
+"<br><br>\n"
+"With a gentle learning curve, NiceGUI is user-friendly for beginners\n"
+"and offers advanced customization for experienced users,\n"
+"ensuring simplicity for basic tasks and feasibility for complex projects."
+"\n"
+"<br><br><br>\n"
+"Available as\n"
+"[PyPI package](https://pypi.org/project/nicegui/),\n"
+"[Docker image](https://hub.docker.com/r/zauberzeug/nicegui) and on\n"
+"[GitHub](https://github.com/zauberzeug/nicegui)."
+msgstr ""
+
+#: website/main_page.py:55
+msgid "Get *started*"
+msgstr "시작하기"
+
+#: website/main_page.py:59
+msgid "Create __main.py__"
+msgstr "__main.py__ 생성"
+
+#: website/main_page.py:72
+msgid "Install and launch"
+msgstr "설치 및 시작"
+
+#: website/main_page.py:82
+msgid "Enjoy!"
+msgstr "즐기세요!"
+
+#: website/main_page.py:85
+msgid "...or use Docker to run your main.py"
+msgstr "...또는 Docker를 사용하여 main.py를 실행하세요"
+
+#: website/main_page.py:88
+msgid ""
+"With our [multi-arch Docker "
+"image](https://hub.docker.com/repository/docker/zauberzeug/nicegui)\n"
+"you can start the server without installing any packages.\n"
+"\n"
+"The command searches for `main.py` in in your current directory and makes"
+" the app available at http://localhost:8888."
+msgstr ""
+
+#: website/main_page.py:103
+msgid "Code *nicely*"
+msgstr "코드 *아름답게*"
+
+#: website/main_page.py:105
+msgid "Interaction"
+msgstr "상호작용"
+
+#: website/main_page.py:106
+msgid "[buttons, switches, sliders, inputs, ...](/documentation/section_controls)"
+msgstr "[버튼, 스위치, 슬라이더, 입력 필드 등](/documentation/section_controls)"
+
+#: website/main_page.py:107
+msgid "[notifications, dialogs and menus](/documentation/section_page_layout)"
+msgstr "[알림, 대화상자 및 메뉴](/documentation/section_page_layout)"
+
+#: website/main_page.py:108
+msgid "[interactive images](/documentation/interactive_image) with SVG overlays"
+msgstr "[반응형 이미지](/documentation/interactive_image)에 SVG 오버레이 적용"
+
+#: website/main_page.py:109
+msgid ""
+"web pages and [native window "
+"apps](/documentation/section_configuration_deployment#native_mode)"
+msgstr "웹 페이지 및 [네이티브 윈도우 애플리케이션](/documentation/section_configuration_deployment#native_mode)"
+
+#: website/main_page.py:111
+msgid "Layout"
+msgstr "레이아웃"
+
+#: website/main_page.py:112
+msgid "[navigation bars, tabs, panels, ...](/documentation/section_page_layout)"
+msgstr "[네비게이션 바, 탭, 패널 등](/documentation/section_page_layout)"
+
+#: website/main_page.py:113
+msgid "grouping with rows, columns, grids and cards"
+msgstr "행, 열, 그리드 및 카드를 사용한 그룹화 레이아웃"
+
+#: website/main_page.py:114
+msgid ""
+"[HTML](/documentation/html) and [Markdown](/documentation/markdown) "
+"elements"
+msgstr "[HTML](/documentation/html) 및 [Markdown](/documentation/markdown) 요소"
+
+#: website/main_page.py:115
+msgid "flex layout by default"
+msgstr "기본값으로 flex 레이아웃"
+
+#: website/main_page.py:117
+msgid "Visualization"
+msgstr "시각화"
+
+#: website/main_page.py:118
+msgid ""
+"[charts, diagrams, tables](/documentation/section_data_elements), "
+"[audio/video](/documentation/section_audiovisual_elements)"
+msgstr "[차트, 다이어그램, 표](/documentation/section_data_elements), [오디오/비디오](/documentation/section_audiovisual_elements)"
+
+#: website/main_page.py:119
+msgid "[3D scenes](/documentation/scene)"
+msgstr "[3D 장면](/documentation/scene)"
+
+#: website/main_page.py:120
+msgid "straight-forward [data binding](/documentation/section_binding_properties)"
+msgstr "직관적인 [데이터 바인딩](/documentation/section_binding_properties)"
+
+#: website/main_page.py:121
+msgid "built-in [timer for data refresh](/documentation/timer)"
+msgstr "내장된 [데이터 새로고침 타이머](/documentation/timer)"
+
+#: website/main_page.py:123
+msgid "Styling"
+msgstr "스타일링"
+
+#: website/main_page.py:124
+msgid ""
+"customizable [color "
+"themes](/documentation/section_styling_appearance#color_theming)"
+msgstr "맞춤형 [색 테마](/documentation/section_styling_appearance#color_theming)"
+
+#: website/main_page.py:125
+msgid "custom CSS and classes"
+msgstr "커스텀 CSS 및 클래스"
+
+#: website/main_page.py:126
+msgid "modern look with material design"
+msgstr "Material Design 스타일의 모던한 외관"
+
+#: website/main_page.py:127
+msgid "[Tailwind CSS](https://tailwindcss.com/)"
+msgstr ""
+
+#: website/main_page.py:129
+msgid "Coding"
+msgstr "프로그래밍"
+
+#: website/main_page.py:130
+msgid "single page apps with [ui.sub_pages](/documentation/sub_pages)"
+msgstr "[ui.sub_pages](/documentation/sub_pages)을 사용한 단일 페이지 애플리케이션"
+
+#: website/main_page.py:131
+msgid "auto-reload on code change"
+msgstr "코드 수정 시 자동 재로드"
+
+#: website/main_page.py:132
+msgid "persistent [user sessions](/documentation/storage)"
+msgstr "지속적인 [사용자 세션](/documentation/storage)"
+
+#: website/main_page.py:133
+msgid "super powerful [testing framework](/documentation/section_testing)"
+msgstr "강력한 [테스트 프레임워크](/documentation/section_testing)"
+
+#: website/main_page.py:135
+msgid "Foundation"
+msgstr "기반 플랫폼"
+
+#: website/main_page.py:136
+msgid "generic [Vue](https://vuejs.org/) to Python bridge"
+msgstr "일반적인 [Vue](https://vuejs.org/)와 Python 간의 브리지"
+
+#: website/main_page.py:137
+msgid "dynamic GUI through [Quasar](https://quasar.dev/)"
+msgstr "[Quasar](https://quasar.dev/)을 사용한 동적 GUI"
+
+#: website/main_page.py:138
+msgid "content is served with [FastAPI](https://fastapi.tiangolo.com/)"
+msgstr "[FastAPI](https://fastapi.tiangolo.com/)를 이용해 콘텐츠를 제공합니다"
+
+#: website/main_page.py:139
+msgid "Python 3.10+"
+msgstr ""
+
+#: website/main_page.py:144
+msgid "Try *this*"
+msgstr "*이것*을试试해 보세요"
+
+#: website/main_page.py:151
+msgid "Browse through plenty of live demos."
+msgstr "많은 실시간 데모를 확인해 보세요."
+
+#: website/main_page.py:153
+msgid "Fun-Fact: This whole website is also coded with NiceGUI."
+msgstr "흥미로운 사실: 이 전체 웹사이트는 NiceGUI를 사용해 개발되었습니다."
+
+#: website/main_page.py:171
+msgid "NiceGUI is supported by"
+msgstr "NiceGUI는 다음의 후원자들에 의해 지원됩니다."
+
+#: website/main_page.py:202
+msgid "Become a sponsor"
+msgstr "스폰서가 되기"
+
+#: website/main_page.py:215
+msgid ""
+"We at\n"
+"[Zauberzeug](https://zauberzeug.com)\n"
+"like\n"
+"[Streamlit](https://streamlit.io/)\n"
+"but find it does\n"
+"[too much "
+"magic](https://github.com/zauberzeug/nicegui/issues/1#issuecomment-847413651)"
+"\n"
+"when it comes to state handling.\n"
+"In search for an alternative nice library to write simple graphical user "
+"interfaces in Python we discovered\n"
+"[JustPy](https://justpy.io/).\n"
+"Although we liked the approach, it is too \"low-level HTML\" for our "
+"daily usage.\n"
+"But it inspired us to use\n"
+"[Vue](https://vuejs.org/)\n"
+"and\n"
+"[Quasar](https://quasar.dev/)\n"
+"for the frontend."
+msgstr ""
+
+#: website/main_page.py:232
+msgid ""
+"We have built on top of\n"
+"[FastAPI](https://fastapi.tiangolo.com/),\n"
+"which itself is based on the ASGI framework\n"
+"[Starlette](https://www.starlette.io/)\n"
+"and the ASGI webserver\n"
+"[Uvicorn](https://www.uvicorn.org/)\n"
+"because of their great performance and ease of use."
+msgstr ""
+
+#: website/main_page.py:242
+msgid "Imprint & Privacy"
+msgstr "인프린트 및 개인정보"
+
+#: website/search.py:41
+msgid "Search documentation"
+msgstr "문서 검색"
+
+#: website/search.py:57
+msgid "Press Ctrl+K or / to search the documentation"
+msgstr "Ctrl+K 또는 /를 누르어 문서 검색"
+
+#: website/star.py:45
+msgid "Star us on GitHub!"
+msgstr "GitHub에서 우리를 스타해 주세요!"
+
+#: website/star.py:46
+msgid "And tell others about NiceGUI."
+msgstr "다른 사람들에게 NiceGUI를 알려줄 수 있습니다."
+
+#: website/style.py:46
+msgid "...and many more"
+msgstr "… 그리고 더 많은 기능"
+
+#: website/style.py:47
+msgid "Browse through plenty of examples."
+msgstr "많은 예제를 확인해 보세요."
+
+#: website/documentation/intro.py:13
+msgid "Single-Page Applications"
+msgstr "단일 페이지 애플리케이션"
+
+#: website/documentation/intro.py:14
+msgid ""
+"Build applications with fast client-side routing using "
+"[`ui.sub_pages`](/documentation/sub_pages)\n"
+"and a `root` function as single entry point.\n"
+"For each visitor, the `root` function is executed and generates the "
+"interface.\n"
+"[`ui.link`](/documentation/link) and "
+"[`ui.navigate`](/documentation/navigate) can be used to navigate to other"
+" sub pages.\n"
+"\n"
+"If you do not want a single-page application, you can also use "
+"[`@ui.page('/your/path')`](/documentation/page)\n"
+"to define standalone content available at a specific path."
+msgstr ""
+
+#: website/documentation/intro.py:50
+msgid "Reactive Transformations"
+msgstr ""
+"반응형 변환\n"
+"\n"
+"[이번에는 원문을 다시 보고, 참고 번역과 일치하는 방식으로 번역합니다.]"
+
+#: website/documentation/intro.py:51
+msgid ""
+"Create real-time interfaces with automatic updates.\n"
+"Type and watch text flow in both directions.\n"
+"When input changes, the "
+"[binding](/documentation/section_binding_properties) transforms the text"
+"\n"
+"with a custom Python function and updates the label."
+msgstr ""
+
+#: website/documentation/intro.py:66
+msgid "Event System"
+msgstr "이벤트 시스템"
+
+#: website/documentation/intro.py:67
+msgid ""
+"Use an [Event](/documentation/event) to trigger actions and pass data.\n"
+"Here we have an IoT temperature sensor submitting its readings\n"
+"to a [FastAPI "
+"endpoint](/documentation/section_pages_routing#api_responses) with path "
+"\"/sensor\".\n"
+"When a new value arrives, it emits an event for the chart to be updated."
+msgstr ""

--- a/website/translations/messages.pot
+++ b/website/translations/messages.pot
@@ -1,0 +1,393 @@
+# Translations template for PROJECT.
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-02-27 09:15+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "In-depth examples"
+msgstr ""
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "Pick your *solution*"
+msgstr ""
+
+#: website/header.py:30 website/main_page.py:55
+msgid "Installation"
+msgstr ""
+
+#: website/header.py:31 website/main_page.py:103
+msgid "Features"
+msgstr ""
+
+#: website/header.py:32 website/main_page.py:144
+msgid "Demos"
+msgstr ""
+
+#: website/header.py:33 website/main_page.py:155
+msgid "Documentation"
+msgstr ""
+
+#: website/header.py:34
+msgid "Examples"
+msgstr ""
+
+#: website/header.py:35 website/main_page.py:212
+msgid "Why?"
+msgstr ""
+
+#: website/header.py:59
+msgid "Cycle theme mode through dark, light, and system/auto."
+msgstr ""
+
+#: website/header.py:67
+msgid "Discord"
+msgstr ""
+
+#: website/header.py:69
+msgid "Reddit"
+msgstr ""
+
+#: website/header.py:71
+msgid "GitHub"
+msgstr ""
+
+#: website/main_page.py:21
+msgid "Meet the *NiceGUI*."
+msgstr ""
+
+#: website/main_page.py:22
+msgid "And let any browser be the frontend of your Python code."
+msgstr ""
+
+#: website/main_page.py:34
+msgid ""
+"Interact with Python through buttons, dialogs, 3D&nbsp;scenes, plots and "
+"much more."
+msgstr ""
+
+#: website/main_page.py:37
+msgid ""
+"NiceGUI manages web development details, letting you focus on Python code"
+" for diverse applications,\n"
+"including robotics, IoT solutions, smart home automation, and machine "
+"learning.\n"
+"Designed to work smoothly with connected peripherals like webcams and "
+"GPIO pins in IoT setups,\n"
+"NiceGUI streamlines the management of all your code in one place.\n"
+"<br><br>\n"
+"With a gentle learning curve, NiceGUI is user-friendly for beginners\n"
+"and offers advanced customization for experienced users,\n"
+"ensuring simplicity for basic tasks and feasibility for complex projects."
+"\n"
+"<br><br><br>\n"
+"Available as\n"
+"[PyPI package](https://pypi.org/project/nicegui/),\n"
+"[Docker image](https://hub.docker.com/r/zauberzeug/nicegui) and on\n"
+"[GitHub](https://github.com/zauberzeug/nicegui)."
+msgstr ""
+
+#: website/main_page.py:55
+msgid "Get *started*"
+msgstr ""
+
+#: website/main_page.py:59
+msgid "Create __main.py__"
+msgstr ""
+
+#: website/main_page.py:72
+msgid "Install and launch"
+msgstr ""
+
+#: website/main_page.py:82
+msgid "Enjoy!"
+msgstr ""
+
+#: website/main_page.py:85
+msgid "...or use Docker to run your main.py"
+msgstr ""
+
+#: website/main_page.py:88
+msgid ""
+"With our [multi-arch Docker "
+"image](https://hub.docker.com/repository/docker/zauberzeug/nicegui)\n"
+"you can start the server without installing any packages.\n"
+"\n"
+"The command searches for `main.py` in in your current directory and makes"
+" the app available at http://localhost:8888."
+msgstr ""
+
+#: website/main_page.py:103
+msgid "Code *nicely*"
+msgstr ""
+
+#: website/main_page.py:105
+msgid "Interaction"
+msgstr ""
+
+#: website/main_page.py:106
+msgid "[buttons, switches, sliders, inputs, ...](/documentation/section_controls)"
+msgstr ""
+
+#: website/main_page.py:107
+msgid "[notifications, dialogs and menus](/documentation/section_page_layout)"
+msgstr ""
+
+#: website/main_page.py:108
+msgid "[interactive images](/documentation/interactive_image) with SVG overlays"
+msgstr ""
+
+#: website/main_page.py:109
+msgid ""
+"web pages and [native window "
+"apps](/documentation/section_configuration_deployment#native_mode)"
+msgstr ""
+
+#: website/main_page.py:111
+msgid "Layout"
+msgstr ""
+
+#: website/main_page.py:112
+msgid "[navigation bars, tabs, panels, ...](/documentation/section_page_layout)"
+msgstr ""
+
+#: website/main_page.py:113
+msgid "grouping with rows, columns, grids and cards"
+msgstr ""
+
+#: website/main_page.py:114
+msgid ""
+"[HTML](/documentation/html) and [Markdown](/documentation/markdown) "
+"elements"
+msgstr ""
+
+#: website/main_page.py:115
+msgid "flex layout by default"
+msgstr ""
+
+#: website/main_page.py:117
+msgid "Visualization"
+msgstr ""
+
+#: website/main_page.py:118
+msgid ""
+"[charts, diagrams, tables](/documentation/section_data_elements), "
+"[audio/video](/documentation/section_audiovisual_elements)"
+msgstr ""
+
+#: website/main_page.py:119
+msgid "[3D scenes](/documentation/scene)"
+msgstr ""
+
+#: website/main_page.py:120
+msgid "straight-forward [data binding](/documentation/section_binding_properties)"
+msgstr ""
+
+#: website/main_page.py:121
+msgid "built-in [timer for data refresh](/documentation/timer)"
+msgstr ""
+
+#: website/main_page.py:123
+msgid "Styling"
+msgstr ""
+
+#: website/main_page.py:124
+msgid ""
+"customizable [color "
+"themes](/documentation/section_styling_appearance#color_theming)"
+msgstr ""
+
+#: website/main_page.py:125
+msgid "custom CSS and classes"
+msgstr ""
+
+#: website/main_page.py:126
+msgid "modern look with material design"
+msgstr ""
+
+#: website/main_page.py:127
+msgid "[Tailwind CSS](https://tailwindcss.com/)"
+msgstr ""
+
+#: website/main_page.py:129
+msgid "Coding"
+msgstr ""
+
+#: website/main_page.py:130
+msgid "single page apps with [ui.sub_pages](/documentation/sub_pages)"
+msgstr ""
+
+#: website/main_page.py:131
+msgid "auto-reload on code change"
+msgstr ""
+
+#: website/main_page.py:132
+msgid "persistent [user sessions](/documentation/storage)"
+msgstr ""
+
+#: website/main_page.py:133
+msgid "super powerful [testing framework](/documentation/section_testing)"
+msgstr ""
+
+#: website/main_page.py:135
+msgid "Foundation"
+msgstr ""
+
+#: website/main_page.py:136
+msgid "generic [Vue](https://vuejs.org/) to Python bridge"
+msgstr ""
+
+#: website/main_page.py:137
+msgid "dynamic GUI through [Quasar](https://quasar.dev/)"
+msgstr ""
+
+#: website/main_page.py:138
+msgid "content is served with [FastAPI](https://fastapi.tiangolo.com/)"
+msgstr ""
+
+#: website/main_page.py:139
+msgid "Python 3.10+"
+msgstr ""
+
+#: website/main_page.py:144
+msgid "Try *this*"
+msgstr ""
+
+#: website/main_page.py:151
+msgid "Browse through plenty of live demos."
+msgstr ""
+
+#: website/main_page.py:153
+msgid "Fun-Fact: This whole website is also coded with NiceGUI."
+msgstr ""
+
+#: website/main_page.py:171
+msgid "NiceGUI is supported by"
+msgstr ""
+
+#: website/main_page.py:202
+msgid "Become a sponsor"
+msgstr ""
+
+#: website/main_page.py:215
+msgid ""
+"We at\n"
+"[Zauberzeug](https://zauberzeug.com)\n"
+"like\n"
+"[Streamlit](https://streamlit.io/)\n"
+"but find it does\n"
+"[too much "
+"magic](https://github.com/zauberzeug/nicegui/issues/1#issuecomment-847413651)"
+"\n"
+"when it comes to state handling.\n"
+"In search for an alternative nice library to write simple graphical user "
+"interfaces in Python we discovered\n"
+"[JustPy](https://justpy.io/).\n"
+"Although we liked the approach, it is too \"low-level HTML\" for our "
+"daily usage.\n"
+"But it inspired us to use\n"
+"[Vue](https://vuejs.org/)\n"
+"and\n"
+"[Quasar](https://quasar.dev/)\n"
+"for the frontend."
+msgstr ""
+
+#: website/main_page.py:232
+msgid ""
+"We have built on top of\n"
+"[FastAPI](https://fastapi.tiangolo.com/),\n"
+"which itself is based on the ASGI framework\n"
+"[Starlette](https://www.starlette.io/)\n"
+"and the ASGI webserver\n"
+"[Uvicorn](https://www.uvicorn.org/)\n"
+"because of their great performance and ease of use."
+msgstr ""
+
+#: website/main_page.py:242
+msgid "Imprint & Privacy"
+msgstr ""
+
+#: website/search.py:41
+msgid "Search documentation"
+msgstr ""
+
+#: website/search.py:57
+msgid "Press Ctrl+K or / to search the documentation"
+msgstr ""
+
+#: website/star.py:45
+msgid "Star us on GitHub!"
+msgstr ""
+
+#: website/star.py:46
+msgid "And tell others about NiceGUI."
+msgstr ""
+
+#: website/style.py:46
+msgid "...and many more"
+msgstr ""
+
+#: website/style.py:47
+msgid "Browse through plenty of examples."
+msgstr ""
+
+#: website/documentation/intro.py:13
+msgid "Single-Page Applications"
+msgstr ""
+
+#: website/documentation/intro.py:14
+msgid ""
+"Build applications with fast client-side routing using "
+"[`ui.sub_pages`](/documentation/sub_pages)\n"
+"and a `root` function as single entry point.\n"
+"For each visitor, the `root` function is executed and generates the "
+"interface.\n"
+"[`ui.link`](/documentation/link) and "
+"[`ui.navigate`](/documentation/navigate) can be used to navigate to other"
+" sub pages.\n"
+"\n"
+"If you do not want a single-page application, you can also use "
+"[`@ui.page('/your/path')`](/documentation/page)\n"
+"to define standalone content available at a specific path."
+msgstr ""
+
+#: website/documentation/intro.py:50
+msgid "Reactive Transformations"
+msgstr ""
+
+#: website/documentation/intro.py:51
+msgid ""
+"Create real-time interfaces with automatic updates.\n"
+"Type and watch text flow in both directions.\n"
+"When input changes, the "
+"[binding](/documentation/section_binding_properties) transforms the text"
+"\n"
+"with a custom Python function and updates the label."
+msgstr ""
+
+#: website/documentation/intro.py:66
+msgid "Event System"
+msgstr ""
+
+#: website/documentation/intro.py:67
+msgid ""
+"Use an [Event](/documentation/event) to trigger actions and pass data.\n"
+"Here we have an IoT temperature sensor submitting its readings\n"
+"to a [FastAPI "
+"endpoint](/documentation/section_pages_routing#api_responses) with path "
+"\"/sensor\".\n"
+"When a new value arrives, it emits an event for the chart to be updated."
+msgstr ""

--- a/website/translations/zh/LC_MESSAGES/messages.po
+++ b/website/translations/zh/LC_MESSAGES/messages.po
@@ -1,0 +1,447 @@
+# Chinese translations for PROJECT.
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-02-27 09:15+0000\n"
+"PO-Revision-Date: 2026-02-27 09:15+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh\n"
+"Language-Team: zh <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "In-depth examples"
+msgstr "深入示例"
+
+#: website/examples_page.py:11 website/main_page.py:160
+msgid "Pick your *solution*"
+msgstr "挑选您的*方案*"
+
+#: website/header.py:30 website/main_page.py:55
+msgid "Installation"
+msgstr "安装"
+
+#: website/header.py:31 website/main_page.py:103
+msgid "Features"
+msgstr "功能"
+
+#: website/header.py:32 website/main_page.py:144
+msgid "Demos"
+msgstr "演示"
+
+#: website/header.py:33 website/main_page.py:155
+msgid "Documentation"
+msgstr "文档"
+
+#: website/header.py:34
+msgid "Examples"
+msgstr "示例"
+
+#: website/header.py:35 website/main_page.py:212
+msgid "Why?"
+msgstr "为什么？"
+
+#: website/header.py:59
+msgid "Cycle theme mode through dark, light, and system/auto."
+msgstr "切换主题模式：深色、浅色和系统/自动。"
+
+#: website/header.py:67
+msgid "Discord"
+msgstr "Discord"
+
+#: website/header.py:69
+msgid "Reddit"
+msgstr "Reddit"
+
+#: website/header.py:71
+msgid "GitHub"
+msgstr "GitHub"
+
+#: website/main_page.py:21
+msgid "Meet the *NiceGUI*."
+msgstr "遇见 *NiceGUI*。"
+
+#: website/main_page.py:22
+msgid "And let any browser be the frontend of your Python code."
+msgstr "让任何浏览器成为您 Python 代码的前端。"
+
+#: website/main_page.py:34
+msgid ""
+"Interact with Python through buttons, dialogs, 3D&nbsp;scenes, plots and "
+"much more."
+msgstr "通过按钮、对话框、3D&nbsp;场景、图表等与 Python 交互。"
+
+#: website/main_page.py:37
+msgid ""
+"NiceGUI manages web development details, letting you focus on Python code"
+" for diverse applications,\n"
+"including robotics, IoT solutions, smart home automation, and machine "
+"learning.\n"
+"Designed to work smoothly with connected peripherals like webcams and "
+"GPIO pins in IoT setups,\n"
+"NiceGUI streamlines the management of all your code in one place.\n"
+"<br><br>\n"
+"With a gentle learning curve, NiceGUI is user-friendly for beginners\n"
+"and offers advanced customization for experienced users,\n"
+"ensuring simplicity for basic tasks and feasibility for complex projects."
+"\n"
+"<br><br><br>\n"
+"Available as\n"
+"[PyPI package](https://pypi.org/project/nicegui/),\n"
+"[Docker image](https://hub.docker.com/r/zauberzeug/nicegui) and on\n"
+"[GitHub](https://github.com/zauberzeug/nicegui)."
+msgstr ""
+"NiceGUI 处理 Web 开发的细节，让您专注于 Python 代码，适用于各种应用场景，\n"
+"包括机器人、物联网解决方案、智能家居自动化和机器学习。\n"
+"旨在与网络摄像头和 GPIO 引脚等外围设备顺畅配合，\n"
+"NiceGUI 让您在一个地方管理所有代码。\n"
+"<br><br>\n"
+"学习曲线平缓，NiceGUI 对初学者友好，\n"
+"同时为有经验的用户提供高级自定义选项，\n"
+"确保简单任务的简洁性和复杂项目的可行性。\n"
+"<br><br><br>\n"
+"可通过\n"
+"[PyPI 包](https://pypi.org/project/nicegui/)、\n"
+"[Docker 镜像](https://hub.docker.com/r/zauberzeug/nicegui) 和\n"
+"[GitHub](https://github.com/zauberzeug/nicegui) 获取。"
+
+#: website/main_page.py:55
+msgid "Get *started*"
+msgstr "开始*使用*"
+
+#: website/main_page.py:59
+msgid "Create __main.py__"
+msgstr "创建 __main.py__"
+
+#: website/main_page.py:72
+msgid "Install and launch"
+msgstr "安装并启动"
+
+#: website/main_page.py:82
+msgid "Enjoy!"
+msgstr "开始体验！"
+
+#: website/main_page.py:85
+msgid "...or use Docker to run your main.py"
+msgstr "……或使用 Docker 运行您的 main.py"
+
+#: website/main_page.py:88
+msgid ""
+"With our [multi-arch Docker "
+"image](https://hub.docker.com/repository/docker/zauberzeug/nicegui)\n"
+"you can start the server without installing any packages.\n"
+"\n"
+"The command searches for `main.py` in in your current directory and makes"
+" the app available at http://localhost:8888."
+msgstr ""
+"使用我们的[多架构 Docker 镜像](https://hub.docker.com/repository/docker/zauberzeug/nicegui)，\n"
+"您可以无需安装任何软件包即可启动服务器。\n"
+"\n"
+"该命令会在当前目录中搜索 `main.py` 并使应用在 http://localhost:8888 上可用。"
+
+#: website/main_page.py:103
+msgid "Code *nicely*"
+msgstr "优雅*编程*"
+
+#: website/main_page.py:105
+msgid "Interaction"
+msgstr "交互"
+
+#: website/main_page.py:106
+msgid "[buttons, switches, sliders, inputs, ...](/documentation/section_controls)"
+msgstr "[按钮、开关、滑块、输入框等](/documentation/section_controls)"
+
+#: website/main_page.py:107
+msgid "[notifications, dialogs and menus](/documentation/section_page_layout)"
+msgstr "[通知、对话框和菜单](/documentation/section_page_layout)"
+
+#: website/main_page.py:108
+msgid "[interactive images](/documentation/interactive_image) with SVG overlays"
+msgstr "[交互式图像](/documentation/interactive_image)（支持 SVG 叠加）"
+
+#: website/main_page.py:109
+msgid ""
+"web pages and [native window "
+"apps](/documentation/section_configuration_deployment#native_mode)"
+msgstr "网页和[原生窗口应用](/documentation/section_configuration_deployment#native_mode)"
+
+#: website/main_page.py:111
+msgid "Layout"
+msgstr "布局"
+
+#: website/main_page.py:112
+msgid "[navigation bars, tabs, panels, ...](/documentation/section_page_layout)"
+msgstr "[导航栏、标签页、面板等](/documentation/section_page_layout)"
+
+#: website/main_page.py:113
+msgid "grouping with rows, columns, grids and cards"
+msgstr "通过行、列、网格和卡片进行分组"
+
+#: website/main_page.py:114
+msgid ""
+"[HTML](/documentation/html) and [Markdown](/documentation/markdown) "
+"elements"
+msgstr "[HTML](/documentation/html) 和 [Markdown](/documentation/markdown) 元素"
+
+#: website/main_page.py:115
+msgid "flex layout by default"
+msgstr "默认弹性布局"
+
+#: website/main_page.py:117
+msgid "Visualization"
+msgstr "可视化"
+
+#: website/main_page.py:118
+msgid ""
+"[charts, diagrams, tables](/documentation/section_data_elements), "
+"[audio/video](/documentation/section_audiovisual_elements)"
+msgstr "[图表、图示、表格](/documentation/section_data_elements)、[音频/视频](/documentation/section_audiovisual_elements)"
+
+#: website/main_page.py:119
+msgid "[3D scenes](/documentation/scene)"
+msgstr "[3D 场景](/documentation/scene)"
+
+#: website/main_page.py:120
+msgid "straight-forward [data binding](/documentation/section_binding_properties)"
+msgstr "简洁的[数据绑定](/documentation/section_binding_properties)"
+
+#: website/main_page.py:121
+msgid "built-in [timer for data refresh](/documentation/timer)"
+msgstr "内置[数据刷新定时器](/documentation/timer)"
+
+#: website/main_page.py:123
+msgid "Styling"
+msgstr "样式"
+
+#: website/main_page.py:124
+msgid ""
+"customizable [color "
+"themes](/documentation/section_styling_appearance#color_theming)"
+msgstr "可自定义的[颜色主题](/documentation/section_styling_appearance#color_theming)"
+
+#: website/main_page.py:125
+msgid "custom CSS and classes"
+msgstr "自定义 CSS 和类"
+
+#: website/main_page.py:126
+msgid "modern look with material design"
+msgstr "Material Design 现代外观"
+
+#: website/main_page.py:127
+msgid "[Tailwind CSS](https://tailwindcss.com/)"
+msgstr "[Tailwind CSS](https://tailwindcss.com/)"
+
+#: website/main_page.py:129
+msgid "Coding"
+msgstr "编程"
+
+#: website/main_page.py:130
+msgid "single page apps with [ui.sub_pages](/documentation/sub_pages)"
+msgstr "使用 [ui.sub_pages](/documentation/sub_pages) 构建单页应用"
+
+#: website/main_page.py:131
+msgid "auto-reload on code change"
+msgstr "代码更改时自动重载"
+
+#: website/main_page.py:132
+msgid "persistent [user sessions](/documentation/storage)"
+msgstr "持久化[用户会话](/documentation/storage)"
+
+#: website/main_page.py:133
+msgid "super powerful [testing framework](/documentation/section_testing)"
+msgstr "超强大的[测试框架](/documentation/section_testing)"
+
+#: website/main_page.py:135
+msgid "Foundation"
+msgstr "基础"
+
+#: website/main_page.py:136
+msgid "generic [Vue](https://vuejs.org/) to Python bridge"
+msgstr "通用的 [Vue](https://vuejs.org/) 到 Python 桥接"
+
+#: website/main_page.py:137
+msgid "dynamic GUI through [Quasar](https://quasar.dev/)"
+msgstr "通过 [Quasar](https://quasar.dev/) 实现动态 GUI"
+
+#: website/main_page.py:138
+msgid "content is served with [FastAPI](https://fastapi.tiangolo.com/)"
+msgstr "内容由 [FastAPI](https://fastapi.tiangolo.com/) 提供"
+
+#: website/main_page.py:139
+msgid "Python 3.10+"
+msgstr "Python 3.10+"
+
+#: website/main_page.py:144
+msgid "Try *this*"
+msgstr "试试*看*"
+
+#: website/main_page.py:151
+msgid "Browse through plenty of live demos."
+msgstr "浏览大量在线演示。"
+
+#: website/main_page.py:153
+msgid "Fun-Fact: This whole website is also coded with NiceGUI."
+msgstr "趣闻：整个网站也是用 NiceGUI 编写的。"
+
+#: website/main_page.py:171
+msgid "NiceGUI is supported by"
+msgstr "NiceGUI 由以下赞助商支持"
+
+#: website/main_page.py:202
+msgid "Become a sponsor"
+msgstr "成为赞助商"
+
+#: website/main_page.py:215
+msgid ""
+"We at\n"
+"[Zauberzeug](https://zauberzeug.com)\n"
+"like\n"
+"[Streamlit](https://streamlit.io/)\n"
+"but find it does\n"
+"[too much "
+"magic](https://github.com/zauberzeug/nicegui/issues/1#issuecomment-847413651)"
+"\n"
+"when it comes to state handling.\n"
+"In search for an alternative nice library to write simple graphical user "
+"interfaces in Python we discovered\n"
+"[JustPy](https://justpy.io/).\n"
+"Although we liked the approach, it is too \"low-level HTML\" for our "
+"daily usage.\n"
+"But it inspired us to use\n"
+"[Vue](https://vuejs.org/)\n"
+"and\n"
+"[Quasar](https://quasar.dev/)\n"
+"for the frontend."
+msgstr ""
+"我们\n"
+"[Zauberzeug](https://zauberzeug.com)\n"
+"喜欢\n"
+"[Streamlit](https://streamlit.io/)，\n"
+"但发现它在状态管理方面\n"
+"[过于神奇](https://github.com/zauberzeug/nicegui/issues/1#issuecomment-847413651)。\n"
+"在寻找一个用 Python 编写简单图形用户界面的优秀替代库时，我们发现了\n"
+"[JustPy](https://justpy.io/)。\n"
+"虽然我们喜欢这种方式，但它对于日常使用来说太 \"底层 HTML\" 了。\n"
+"不过它启发我们使用\n"
+"[Vue](https://vuejs.org/)\n"
+"和\n"
+"[Quasar](https://quasar.dev/)\n"
+"作为前端。"
+
+#: website/main_page.py:232
+msgid ""
+"We have built on top of\n"
+"[FastAPI](https://fastapi.tiangolo.com/),\n"
+"which itself is based on the ASGI framework\n"
+"[Starlette](https://www.starlette.io/)\n"
+"and the ASGI webserver\n"
+"[Uvicorn](https://www.uvicorn.org/)\n"
+"because of their great performance and ease of use."
+msgstr ""
+"我们基于\n"
+"[FastAPI](https://fastapi.tiangolo.com/) 构建，\n"
+"它本身基于 ASGI 框架\n"
+"[Starlette](https://www.starlette.io/)\n"
+"和 ASGI Web 服务器\n"
+"[Uvicorn](https://www.uvicorn.org/)，\n"
+"因为它们具有出色的性能和易用性。"
+
+#: website/main_page.py:242
+msgid "Imprint & Privacy"
+msgstr "版权声明与隐私政策"
+
+#: website/search.py:41
+msgid "Search documentation"
+msgstr "搜索文档"
+
+#: website/search.py:57
+msgid "Press Ctrl+K or / to search the documentation"
+msgstr "按 Ctrl+K 或 / 搜索文档"
+
+#: website/star.py:45
+msgid "Star us on GitHub!"
+msgstr "在 GitHub 上给我们加星！"
+
+#: website/star.py:46
+msgid "And tell others about NiceGUI."
+msgstr "并告诉其他人关于 NiceGUI。"
+
+#: website/style.py:46
+msgid "...and many more"
+msgstr "……还有更多"
+
+#: website/style.py:47
+msgid "Browse through plenty of examples."
+msgstr "浏览大量示例。"
+
+#: website/documentation/intro.py:13
+msgid "Single-Page Applications"
+msgstr "单页应用"
+
+#: website/documentation/intro.py:14
+msgid ""
+"Build applications with fast client-side routing using "
+"[`ui.sub_pages`](/documentation/sub_pages)\n"
+"and a `root` function as single entry point.\n"
+"For each visitor, the `root` function is executed and generates the "
+"interface.\n"
+"[`ui.link`](/documentation/link) and "
+"[`ui.navigate`](/documentation/navigate) can be used to navigate to other"
+" sub pages.\n"
+"\n"
+"If you do not want a single-page application, you can also use "
+"[`@ui.page('/your/path')`](/documentation/page)\n"
+"to define standalone content available at a specific path."
+msgstr ""
+"使用 [`ui.sub_pages`](/documentation/sub_pages) 和 `root` 函数作为单一入口点，\n"
+"构建具有快速客户端路由的应用。\n"
+"对于每个访客，`root` 函数会执行并生成界面。\n"
+"[`ui.link`](/documentation/link) 和 [`ui.navigate`](/documentation/navigate) 可用于导航到其他子页面。\n"
+"\n"
+"如果不需要单页应用，也可以使用 [`@ui.page('/your/path')`](/documentation/page)\n"
+"来定义在特定路径上可用的独立内容。"
+
+#: website/documentation/intro.py:50
+msgid "Reactive Transformations"
+msgstr "响应式转换"
+
+#: website/documentation/intro.py:51
+msgid ""
+"Create real-time interfaces with automatic updates.\n"
+"Type and watch text flow in both directions.\n"
+"When input changes, the "
+"[binding](/documentation/section_binding_properties) transforms the text"
+"\n"
+"with a custom Python function and updates the label."
+msgstr ""
+"创建具有自动更新的实时界面。\n"
+"输入并观察文本双向流动。\n"
+"当输入更改时，[绑定](/documentation/section_binding_properties)会使用自定义 Python 函数\n"
+"转换文本并更新标签。"
+
+#: website/documentation/intro.py:66
+msgid "Event System"
+msgstr "事件系统"
+
+#: website/documentation/intro.py:67
+msgid ""
+"Use an [Event](/documentation/event) to trigger actions and pass data.\n"
+"Here we have an IoT temperature sensor submitting its readings\n"
+"to a [FastAPI "
+"endpoint](/documentation/section_pages_routing#api_responses) with path "
+"\"/sensor\".\n"
+"When a new value arrives, it emits an event for the chart to be updated."
+msgstr ""
+"使用 [Event](/documentation/event) 触发操作并传递数据。\n"
+"这里有一个物联网温度传感器将其读数\n"
+"提交到路径为 \"/sensor\" 的 [FastAPI 端点](/documentation/section_pages_routing#api_responses)。\n"
+"当新值到达时，它会发出事件以更新图表。"


### PR DESCRIPTION
## What this branch does
Adds i18n support using the standard gettext/Babel toolchain with a `t()` translation function backed by .po catalogs. Features URL-based language routing (/de/, /ja/, /ko/, /zh/) for SEO, auto-compilation of .po to .mo files (no build step needed), and a language switcher in the header. Includes Chinese translations for 73 Layer 1+2 strings with empty catalogs initialized for de, ja, ko.

## Status
Experimental — a distinct approach from the CSV-based i18n branches, using the well-established gettext ecosystem instead. Valuable as a reference for comparing i18n implementation strategies (gettext .po files vs custom CSV system).

## Files changed
17 files, key additions: `website/i18n.py`, `babel.cfg`, `website/translations/{zh,de,ja,ko}/LC_MESSAGES/messages.po`, `website/translations/messages.pot`

## Upstream PR
None yet