### PR TITLE
Address review feedback for #5303 (lazy imports)

### DIFF
--- a/nicegui/elements/aggrid/__init__.py
+++ b/nicegui/elements/aggrid/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-aggrid', {'AgGrid': '.aggrid'})
-__all__ = ['AgGrid']  # pylint: disable=undefined-all-variable
+__all__ = ['AgGrid']
+
+if TYPE_CHECKING:
+    from .aggrid import AgGrid

--- a/nicegui/elements/codemirror/__init__.py
+++ b/nicegui/elements/codemirror/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-codemirror', {'CodeMirror': '.codemirror'})
-__all__ = ['CodeMirror']  # pylint: disable=undefined-all-variable
+__all__ = ['CodeMirror']
+
+if TYPE_CHECKING:
+    from .codemirror import CodeMirror

--- a/nicegui/elements/echart/__init__.py
+++ b/nicegui/elements/echart/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-echart', {'EChart': '.echart'})
-__all__ = ['EChart']  # pylint: disable=undefined-all-variable
+__all__ = ['EChart']
+
+if TYPE_CHECKING:
+    from .echart import EChart

--- a/nicegui/elements/joystick/__init__.py
+++ b/nicegui/elements/joystick/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-joystick', {'Joystick': '.joystick'})
-__all__ = ['Joystick']  # pylint: disable=undefined-all-variable
+__all__ = ['Joystick']
+
+if TYPE_CHECKING:
+    from .joystick import Joystick

--- a/nicegui/elements/json_editor/__init__.py
+++ b/nicegui/elements/json_editor/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-json-editor', {'JsonEditor': '.json_editor'})
-__all__ = ['JsonEditor']  # pylint: disable=undefined-all-variable
+__all__ = ['JsonEditor']
+
+if TYPE_CHECKING:
+    from .json_editor import JsonEditor

--- a/nicegui/elements/leaflet/__init__.py
+++ b/nicegui/elements/leaflet/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-leaflet', {'Leaflet': '.leaflet'})
-__all__ = ['Leaflet']  # pylint: disable=undefined-all-variable
+__all__ = ['Leaflet']
+
+if TYPE_CHECKING:
+    from .leaflet import Leaflet

--- a/nicegui/elements/mermaid/__init__.py
+++ b/nicegui/elements/mermaid/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-mermaid', {'Mermaid': '.mermaid'})
-__all__ = ['Mermaid']  # pylint: disable=undefined-all-variable
+__all__ = ['Mermaid']
+
+if TYPE_CHECKING:
+    from .mermaid import Mermaid

--- a/nicegui/elements/plotly/__init__.py
+++ b/nicegui/elements/plotly/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-plotly', {'Plotly': '.plotly'})
-__all__ = ['Plotly']  # pylint: disable=undefined-all-variable
+__all__ = ['Plotly']
+
+if TYPE_CHECKING:
+    from .plotly import Plotly

--- a/nicegui/elements/scene/__init__.py
+++ b/nicegui/elements/scene/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-scene', {
@@ -7,4 +9,9 @@ __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-scene', {
     'Object3D': '.scene_object3d',
     'SceneView': '.scene_view',
 })
-__all__ = ['Object3D', 'Scene', 'SceneCamera', 'SceneObject', 'SceneView']  # pylint: disable=undefined-all-variable
+__all__ = ['Object3D', 'Scene', 'SceneCamera', 'SceneObject', 'SceneView']
+
+if TYPE_CHECKING:
+    from .scene import Scene, SceneCamera, SceneObject
+    from .scene_object3d import Object3D
+    from .scene_view import SceneView

--- a/nicegui/elements/xterm/__init__.py
+++ b/nicegui/elements/xterm/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ...dependencies import setup_esm_package
 
 __getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-xterm', {'Xterm': '.xterm'})
-__all__ = ['Xterm']  # pylint: disable=undefined-all-variable
+__all__ = ['Xterm']
+
+if TYPE_CHECKING:
+    from .xterm import Xterm

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -1,5 +1,6 @@
 import builtins
 import importlib
+import importlib.util
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -440,7 +441,9 @@ def __getattr__(name: str) -> object:
 
 # Eagerly import element packages with 'dist' dirs so their __init__.py registers ESM modules in the importmap.
 for _module_path in {mp for mp, _ in _LAZY_IMPORTS.values()}:
-    _pkg_dir = Path(__file__).parent / _module_path.lstrip('.').replace('.', '/')
-    if _pkg_dir.is_dir() and (_pkg_dir / 'dist').is_dir():
-        importlib.import_module(_module_path, package='nicegui')
-del _module_path, _pkg_dir  # pylint: disable=undefined-loop-variable
+    _spec = importlib.util.find_spec(_module_path, package='nicegui')
+    if _spec and _spec.submodule_search_locations:
+        _pkg_dir = Path(_spec.submodule_search_locations[0])
+        if (_pkg_dir / 'dist').is_dir():
+            importlib.import_module(_module_path, package='nicegui')
+del _module_path, _spec, _pkg_dir  # pylint: disable=undefined-loop-variable

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,33 @@
+import importlib
+
+import pytest
+
+
+def test_all_names_resolve():
+    from nicegui import ui
+
+    for name in ui.__all__:
+        obj = getattr(ui, name)
+        assert obj is not None, f'ui.{name} resolved to None'
+
+
+def test_dir_returns_expected_names():
+    from nicegui import ui
+
+    ui_dir = dir(ui)
+    for name in ui.__all__:
+        assert name in ui_dir, f'{name!r} missing from dir(ui)'
+
+
+def test_nonexistent_attribute_raises():
+    from nicegui import ui
+
+    with pytest.raises(AttributeError, match='no_such_widget'):
+        _ = ui.no_such_widget
+
+
+def test_lazy_imports_match_all():
+    mod = importlib.import_module('nicegui.ui')
+    lazy = set(mod._LAZY_IMPORTS)
+    all_set = set(mod.__all__)
+    assert lazy == all_set, f'Mismatch: only in _LAZY_IMPORTS={lazy - all_set}, only in __all__={all_set - lazy}'


### PR DESCRIPTION
## Summary
- Add `TYPE_CHECKING` imports in 10 ESM `__init__.py` files to fix pylint E0603
- Remove unnecessary `# pylint: disable=undefined-all-variable` from all 10 ESM packages
- Replace fragile `lstrip('.').replace('.', '/')` path construction with `importlib.util.find_spec`
- Add `tests/test_lazy_imports.py`: all `__all__` names resolve, `dir(ui)` correct, `AttributeError` on bad attr

**Note:** PR description on #5303 still needs updating via GitHub UI to reflect current PEP 562 implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)