### PR TITLE
Future: differential outbox updates to reduce bandwidth beyond VALUE_PROP

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -153,7 +153,7 @@ class Client:
         self.outbox.updates.clear()
         prefix = request.headers.get('X-Forwarded-Prefix', '') + request.scope.get('root_path', '')
         elements = json.dumps({
-            id: element._to_dict() for id, element in self.elements.items()  # pylint: disable=protected-access
+            id: element._to_dict_full() for id, element in self.elements.items()  # pylint: disable=protected-access
         })
         socket_io_js_query_params = {
             **core.app.config.socket_io_js_query_params,

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -446,7 +446,7 @@ class Element(Visibility):
         """Return diff from last sent state and update _last_sent.
 
         Calls _to_dict() exactly once. Use for differential updates.
-        Returns None if nothing changed.
+        Returns None if nothing changed (unless element has update_method).
         """
         current = self._to_dict()
         previous = self._last_sent
@@ -454,7 +454,10 @@ class Element(Visibility):
 
         if previous is None:
             return current
-        return _compute_diff(current, previous)
+        diff = _compute_diff(current, previous)
+        if diff is None and self._update_method:
+            return {}  # ensure element is included so Vue update method gets called
+        return diff
 
     def run_method(self, name: str, *args: Any, timeout: float = 1) -> AwaitableResponse:
         """Run a method on the client side.

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -40,6 +40,10 @@ class ValueElement(Element):
             self._send_update_on_value_change = self.LOOPBACK is True
             self.set_value(self._event_args_to_value(e))
             self._send_update_on_value_change = True
+            if self.LOOPBACK is False:
+                model_value = self._props.get(self.VALUE_PROP)
+                if model_value == e.args or str(model_value) == str(e.args):
+                    self._set_client_prop(self.VALUE_PROP, model_value)
         self.on(f'update:{self.VALUE_PROP}', handle_change, [None], throttle=throttle)
 
     def on_value_change(self, callback: Handler[ValueChangeEventArguments]) -> Self:

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -106,24 +106,18 @@ function replaceUndefinedAttributes(element) {
 
 function deepMergeElement(target, source) {
   const result = { ...target };
-
   for (const key of Object.keys(source)) {
     const sourceVal = source[key];
-
-    if (sourceVal !== null && typeof sourceVal === "object" && !Array.isArray(sourceVal)) {
-      result[key] = { ...(target[key] || {}) };
-      for (const [nestedKey, nestedVal] of Object.entries(sourceVal)) {
-        if (nestedVal === null) {
-          delete result[key][nestedKey];
-        } else {
-          result[key][nestedKey] = nestedVal;
-        }
-      }
+    if (sourceVal === null) {
+      delete result[key];
+    } else if (typeof sourceVal === "object" && !Array.isArray(sourceVal)) {
+      const targetVal = target[key];
+      const isObj = targetVal !== null && typeof targetVal === "object" && !Array.isArray(targetVal);
+      result[key] = deepMergeElement(isObj ? targetVal : {}, sourceVal);
     } else {
       result[key] = sourceVal;
     }
   }
-
   return result;
 }
 

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -100,10 +100,31 @@ function replaceUndefinedAttributes(element) {
   element.text ??= null;
   element.events ??= [];
   element.update_method ??= null;
-  element.slots = {
-    default: { ids: element.children || [] },
-    ...(element.slots ?? {}),
-  };
+  element.children ??= [];
+  element.slots = { ...(element.slots ?? {}), default: { ids: element.children } };
+}
+
+function deepMergeElement(target, source) {
+  const result = { ...target };
+
+  for (const key of Object.keys(source)) {
+    const sourceVal = source[key];
+
+    if (sourceVal !== null && typeof sourceVal === "object" && !Array.isArray(sourceVal)) {
+      result[key] = { ...(target[key] || {}) };
+      for (const [nestedKey, nestedVal] of Object.entries(sourceVal)) {
+        if (nestedVal === null) {
+          delete result[key][nestedKey];
+        } else {
+          result[key][nestedKey] = nestedVal;
+        }
+      }
+    } else {
+      result[key] = sourceVal;
+    }
+  }
+
+  return result;
 }
 
 function getElement(id) {
@@ -478,11 +499,13 @@ function createApp(elements, options) {
         },
         update: async (msg) => {
           let eventListenersChanged = false;
+          const savedForRerender = {};
           for (const [id, element] of Object.entries(msg)) {
             if (element === null) continue;
             if (!(id in this.elements)) continue;
             const oldListenerIds = new Set((this.elements[id]?.events || []).map((ev) => ev.listener_id));
             if (element.events?.some((e) => !oldListenerIds.has(e.listener_id))) {
+              savedForRerender[id] = this.elements[id];
               delete this.elements[id];
               eventListenersChanged = true;
             }
@@ -497,12 +520,15 @@ function createApp(elements, options) {
               delete this.elements[id];
               continue;
             }
-            replaceUndefinedAttributes(element);
-            this.elements[id] = element;
+            const base = savedForRerender[id] ?? this.elements[id];
+            const merged = base ? deepMergeElement(base, element) : element;
+            replaceUndefinedAttributes(merged);
+            this.elements[id] = merged;
           }
 
           await this.$nextTick();
-          for (const [id, element] of Object.entries(msg)) {
+          for (const id of Object.keys(msg)) {
+            const element = this.elements[id];
             if (element?.update_method) {
               getElement(id)?.[element.update_method]();
             }


### PR DESCRIPTION
### Tracking PR — do not merge

This tracks the broader bandwidth optimization idea from zauberzeug/nicegui#5728: sending only changed attributes in outbox updates, not just skipping VALUE_PROP.

### Why keep this

The bool-flag approach (#5933) only skips echoing `VALUE_PROP` back to the client. The original diff machinery from this branch could reduce bandwidth further by omitting **all** unchanged props, classes, styles, etc. For elements with large prop dicts (ag_grid with thousands of rows, plotly, table), this could be significant.

### What blocked it

@falkoschindler's review identified:
- **Performance risk**: `deepcopy` on every element per outbox tick is expensive on hot paths
- **Reconnection correctness**: diffs in message_history could produce stale state on socket-only reconnect
- **Falsy-key edge case**: empty strings disappear from `_to_dict`, causing stale values on client

### Path forward

If bandwidth becomes a bottleneck again:
1. Benchmark `deepcopy` vs `json.loads(json.dumps())` on heavy elements
2. Consider copy-on-diff (only copy when something changed)
3. Ensure `build_response` and `try_rewind` always use full state
4. Handle falsy-key edge case in `_to_dict`

The original implementation is preserved on the `outbox-simplification` branch for reference.