### PR TITLE
Address review feedback for #5785 (ValueElement generic)

### DIFF
--- a/nicegui/elements/carousel.py
+++ b/nicegui/elements/carousel.py
@@ -9,12 +9,12 @@ from .mixins.disableable_element import DisableableElement
 from .mixins.value_element import ValueElement
 
 
-class Carousel(ValueElement[Any]):
+class Carousel(ValueElement[str | None]):
 
     @resolve_defaults
     def __init__(self, *,
                  value: str | CarouselSlide | None = DEFAULT_PROPS['model-value'] | None,
-                 on_value_change: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 on_value_change: Handler[ValueChangeEventArguments[str | None]] | None = None,
                  animated: bool = DEFAULT_PROP | False,
                  arrows: bool = DEFAULT_PROP | False,
                  navigation: bool = DEFAULT_PROP | False,
@@ -30,10 +30,18 @@ class Carousel(ValueElement[Any]):
         :param arrows: whether to show arrows for manual slide navigation (default: `False`)
         :param navigation: whether to show navigation dots for manual slide navigation (default: `False`)
         """
-        super().__init__(tag='q-carousel', value=value, on_value_change=on_value_change)
+        _value = value.props['name'] if isinstance(value, CarouselSlide) else value
+        super().__init__(tag='q-carousel', value=_value, on_value_change=on_value_change)
         self._props['animated'] = animated
         self._props['arrows'] = arrows
         self._props['navigation'] = navigation
+
+    def set_value(self, value: str | CarouselSlide | None) -> None:
+        """Set the value of this element.
+
+        :param value: slide name or `CarouselSlide` element
+        """
+        super().set_value(value.props['name'] if isinstance(value, CarouselSlide) else value)
 
     def _value_to_model_value(self, value: Any) -> Any:
         return value.props['name'] if isinstance(value, CarouselSlide) else value

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -3,7 +3,7 @@ from colorsys import rgb_to_yiq
 from typing import Any
 
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
+from ..events import Handler, ValueChangeEventArguments
 from .button import Button as button
 from .color_picker import ColorPicker as color_picker
 from .mixins.disableable_element import DisableableElement
@@ -14,7 +14,7 @@ HEX_COLOR_PATTERN_6 = re.compile(r'^#([0-9a-fA-F]{6})$')
 HEX_COLOR_PATTERN_3 = re.compile(r'^#([0-9a-fA-F]{3})$')
 
 
-class ColorInput(LabelElement, ValueElement[str], DisableableElement):
+class ColorInput(LabelElement, ValueElement[str | None], DisableableElement):
     LOOPBACK = False
 
     @resolve_defaults
@@ -75,6 +75,3 @@ class ColorInput(LabelElement, ValueElement[str], DisableableElement):
         luminance = rgb_to_yiq(r, g, b)[0]
         icon_color = 'grey-10' if luminance > 0.5 else 'grey-3'
         self.button.style(f'background-color: {color}').props(f'color="{icon_color}"')
-
-    def _event_args_to_value(self, e: GenericEventArguments) -> str:
-        return e.args if e.args is not None else ''

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -3,7 +3,7 @@ from colorsys import rgb_to_yiq
 from typing import Any
 
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import Handler, ValueChangeEventArguments
+from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .button import Button as button
 from .color_picker import ColorPicker as color_picker
 from .mixins.disableable_element import DisableableElement
@@ -75,3 +75,6 @@ class ColorInput(LabelElement, ValueElement[str], DisableableElement):
         luminance = rgb_to_yiq(r, g, b)[0]
         icon_color = 'grey-10' if luminance > 0.5 else 'grey-3'
         self.button.style(f'background-color: {color}').props(f'color="{icon_color}"')
+
+    def _event_args_to_value(self, e: GenericEventArguments) -> str:
+        return e.args if e.args is not None else ''

--- a/nicegui/elements/date_input.py
+++ b/nicegui/elements/date_input.py
@@ -1,5 +1,5 @@
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
+from ..events import Handler, ValueChangeEventArguments
 from .button import Button as button
 from .date import Date as date
 from .menu import Menu as menu
@@ -8,7 +8,7 @@ from .mixins.label_element import LabelElement
 from .mixins.value_element import ValueElement
 
 
-class DateInput(LabelElement, ValueElement[str], DisableableElement):
+class DateInput(LabelElement, ValueElement[str | None], DisableableElement):
     LOOPBACK = False
 
     @resolve_defaults
@@ -57,6 +57,3 @@ class DateInput(LabelElement, ValueElement[str], DisableableElement):
             return {'from': from_date, 'to': to_date}
         else:
             return value
-
-    def _event_args_to_value(self, e: GenericEventArguments) -> str:
-        return e.args if e.args is not None else ''

--- a/nicegui/elements/date_input.py
+++ b/nicegui/elements/date_input.py
@@ -1,5 +1,5 @@
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import Handler, ValueChangeEventArguments
+from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .button import Button as button
 from .date import Date as date
 from .menu import Menu as menu
@@ -57,3 +57,6 @@ class DateInput(LabelElement, ValueElement[str], DisableableElement):
             return {'from': from_date, 'to': to_date}
         else:
             return value
+
+    def _event_args_to_value(self, e: GenericEventArguments) -> str:
+        return e.args if e.args is not None else ''

--- a/nicegui/elements/editor.py
+++ b/nicegui/elements/editor.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from ..defaults import DEFAULT_PROP, resolve_defaults
-from ..events import Handler, ValueChangeEventArguments
+from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
 from .mixins.value_element import ValueElement
 
@@ -32,3 +32,6 @@ class Editor(ValueElement[str], DisableableElement, component='editor.js', defau
         super()._handle_value_change(value)
         if self._send_update_on_value_change:
             self.run_method('updateValue')
+
+    def _event_args_to_value(self, e: GenericEventArguments) -> str:
+        return e.args if e.args is not None else ''

--- a/nicegui/elements/editor.py
+++ b/nicegui/elements/editor.py
@@ -1,12 +1,12 @@
 from typing import Any
 
 from ..defaults import DEFAULT_PROP, resolve_defaults
-from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
+from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
 from .mixins.value_element import ValueElement
 
 
-class Editor(ValueElement[str], DisableableElement, component='editor.js', default_classes='nicegui-editor'):
+class Editor(ValueElement[str | None], DisableableElement, component='editor.js', default_classes='nicegui-editor'):
     VALUE_PROP: str = 'value'
     LOOPBACK = False
 
@@ -15,7 +15,7 @@ class Editor(ValueElement[str], DisableableElement, component='editor.js', defau
                  *,
                  placeholder: str | None = DEFAULT_PROP | None,
                  value: str = DEFAULT_PROP | '',
-                 on_change: Handler[ValueChangeEventArguments[str]] | None = None,
+                 on_change: Handler[ValueChangeEventArguments[str | None]] | None = None,
                  ) -> None:
         """Editor
 
@@ -32,6 +32,3 @@ class Editor(ValueElement[str], DisableableElement, component='editor.js', defau
         super()._handle_value_change(value)
         if self._send_update_on_value_change:
             self.run_method('updateValue')
-
-    def _event_args_to_value(self, e: GenericEventArguments) -> str:
-        return e.args if e.args is not None else ''

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
+from ..events import Handler, ValueChangeEventArguments
 from .icon import Icon
 from .mixins.disableable_element import DisableableElement
 from .mixins.label_element import LabelElement
 from .mixins.validation_element import ValidationDict, ValidationElement, ValidationFunction
 
 
-class Input(LabelElement, ValidationElement[str], DisableableElement, component='input.js'):
+class Input(LabelElement, ValidationElement[str | None], DisableableElement, component='input.js'):
     VALUE_PROP: str = 'value'
     LOOPBACK = False
 
@@ -114,6 +114,3 @@ class Input(LabelElement, ValidationElement[str], DisableableElement, component=
         super()._handle_value_change(value)
         if self._send_update_on_value_change:
             self.run_method('updateValue')
-
-    def _event_args_to_value(self, e: GenericEventArguments) -> str:
-        return e.args if e.args is not None else ''

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import Handler, ValueChangeEventArguments
+from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .icon import Icon
 from .mixins.disableable_element import DisableableElement
 from .mixins.label_element import LabelElement
@@ -114,3 +114,6 @@ class Input(LabelElement, ValidationElement[str], DisableableElement, component=
         super()._handle_value_change(value)
         if self._send_update_on_value_change:
             self.run_method('updateValue')
+
+    def _event_args_to_value(self, e: GenericEventArguments) -> str:
+        return e.args if e.args is not None else ''

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -4,13 +4,14 @@ from typing import Any, TypeAlias, cast
 from typing_extensions import Self
 
 from ... import background_tasks, helpers
-from .value_element import V, ValueElement
+from ...events import ValueT
+from .value_element import ValueElement
 
 ValidationFunction: TypeAlias = Callable[[Any], str | None | Awaitable[str | None]]
 ValidationDict = dict[str, Callable[[Any], bool]]
 
 
-class ValidationElement(ValueElement[V]):
+class ValidationElement(ValueElement[ValueT]):
 
     def __init__(self, validation: ValidationFunction | ValidationDict | None, **kwargs: Any) -> None:
         self._validation = validation
@@ -89,7 +90,7 @@ class ValidationElement(ValueElement[V]):
         self._auto_validation = False
         return self
 
-    def _handle_value_change(self, value: V) -> None:
+    def _handle_value_change(self, value: ValueT) -> None:
         super()._handle_value_change(value)
         if self._auto_validation:
             self.validate(return_result=False)

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -1,16 +1,14 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, cast
 
 from typing_extensions import Self
 
 from ...binding import BindableProperty, bind, bind_from, bind_to
 from ...element import Element
-from ...events import GenericEventArguments, Handler, ValueChangeEventArguments, handle_event
-
-V = TypeVar('V')
+from ...events import GenericEventArguments, Handler, ValueChangeEventArguments, ValueT, handle_event
 
 
-class ValueElement(Element, Generic[V]):
+class ValueElement(Element, Generic[ValueT]):
     VALUE_PROP: str = 'model-value'
     '''Name of the prop that holds the value of the element'''
 
@@ -26,11 +24,11 @@ class ValueElement(Element, Generic[V]):
         on_change=lambda sender, value: cast(Self, sender)._handle_value_change(value))  # pylint: disable=protected-access
 
     if TYPE_CHECKING:
-        value: V  # type: ignore[assignment,no-redef]
+        value: ValueT  # type: ignore[assignment,no-redef]
 
     def __init__(self, *,
-                 value: V,
-                 on_value_change: Handler[ValueChangeEventArguments[V]] | None = None,
+                 value: ValueT,
+                 on_value_change: Handler[ValueChangeEventArguments[ValueT]] | None = None,
                  throttle: float = 0,
                  **kwargs: Any,
                  ) -> None:
@@ -39,7 +37,7 @@ class ValueElement(Element, Generic[V]):
         self.set_value(value)
         self._props[self.VALUE_PROP] = self._value_to_model_value(value)
         self._props['loopback'] = self.LOOPBACK
-        self._change_handlers: list[Handler[ValueChangeEventArguments[V]]] = \
+        self._change_handlers: list[Handler[ValueChangeEventArguments[ValueT]]] = \
             [on_value_change] if on_value_change else []
 
         def handle_change(e: GenericEventArguments) -> None:
@@ -48,7 +46,7 @@ class ValueElement(Element, Generic[V]):
             self._send_update_on_value_change = True
         self.on(f'update:{self.VALUE_PROP}', handle_change, [None], throttle=throttle)
 
-    def on_value_change(self, callback: Handler[ValueChangeEventArguments[V]]) -> Self:
+    def on_value_change(self, callback: Handler[ValueChangeEventArguments[ValueT]]) -> Self:
         """Add a callback to be invoked when the value changes."""
         self._change_handlers.append(callback)
         return self
@@ -56,7 +54,7 @@ class ValueElement(Element, Generic[V]):
     def bind_value_to(self,
                       target_object: Any,
                       target_name: str | tuple[str, ...] = 'value',
-                      forward: Callable[[V], Any] | None = None, *,
+                      forward: Callable[[ValueT], Any] | None = None, *,
                       strict: bool | None = None,
                       ) -> Self:
         """Bind the value of this element to the target object's target_name property.
@@ -77,7 +75,7 @@ class ValueElement(Element, Generic[V]):
     def bind_value_from(self,
                         target_object: Any,
                         target_name: str | tuple[str, ...] = 'value',
-                        backward: Callable[[Any], V] | None = None, *,
+                        backward: Callable[[Any], ValueT] | None = None, *,
                         strict: bool | None = None,
                         ) -> Self:
         """Bind the value of this element from the target object's target_name property.
@@ -98,8 +96,8 @@ class ValueElement(Element, Generic[V]):
     def bind_value(self,
                    target_object: Any,
                    target_name: str | tuple[str, ...] = 'value', *,
-                   forward: Callable[[V], Any] | None = None,
-                   backward: Callable[[Any], V] | None = None,
+                   forward: Callable[[ValueT], Any] | None = None,
+                   backward: Callable[[Any], ValueT] | None = None,
                    strict: bool | None = None,
                    ) -> Self:
         """Bind the value of this element to the target object's target_name property.
@@ -121,14 +119,14 @@ class ValueElement(Element, Generic[V]):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_value(self, value: V) -> None:
+    def set_value(self, value: ValueT) -> None:
         """Set the value of this element.
 
         :param value: The value to set.
         """
         self.value = value
 
-    def _handle_value_change(self, value: V) -> None:
+    def _handle_value_change(self, value: ValueT) -> None:
         previous_value = self._props.get(self.VALUE_PROP)
         with self._props.suspend_updates():
             self._props[self.VALUE_PROP] = self._value_to_model_value(value)
@@ -136,15 +134,15 @@ class ValueElement(Element, Generic[V]):
             self.update()
         args = ValueChangeEventArguments(sender=self, client=self.client,
                                          value=self._value_to_event_value(value),
-                                         previous_value=self._value_to_event_value(cast(V, previous_value)))
+                                         previous_value=self._value_to_event_value(cast(ValueT, previous_value)))
         for handler in self._change_handlers:
             handle_event(handler, args)
 
-    def _event_args_to_value(self, e: GenericEventArguments) -> V:
+    def _event_args_to_value(self, e: GenericEventArguments) -> ValueT:
         return e.args
 
-    def _value_to_model_value(self, value: V) -> Any:
+    def _value_to_model_value(self, value: ValueT) -> Any:
         return value
 
-    def _value_to_event_value(self, value: V) -> Any:
+    def _value_to_event_value(self, value: ValueT) -> Any:
         return value

--- a/nicegui/elements/stepper.py
+++ b/nicegui/elements/stepper.py
@@ -11,12 +11,12 @@ from .mixins.icon_element import IconElement
 from .mixins.value_element import ValueElement
 
 
-class Stepper(ValueElement[Any], default_classes='nicegui-stepper'):
+class Stepper(ValueElement[str | None], default_classes='nicegui-stepper'):
 
     @resolve_defaults
     def __init__(self, *,
                  value: str | Step | None = DEFAULT_PROPS['model-value'] | None,
-                 on_value_change: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 on_value_change: Handler[ValueChangeEventArguments[str | None]] | None = None,
                  keep_alive: bool = DEFAULT_PROP | True,
                  ) -> None:
         """Stepper
@@ -32,8 +32,16 @@ class Stepper(ValueElement[Any], default_classes='nicegui-stepper'):
         :param on_value_change: callback to be executed when the selected step changes
         :param keep_alive: whether to use Vue's keep-alive component on the content (default: `True`)
         """
-        super().__init__(tag='q-stepper', value=value, on_value_change=on_value_change)
+        _value = cast('str | None', value.props['name'] if isinstance(value, Step) else value)
+        super().__init__(tag='q-stepper', value=_value, on_value_change=on_value_change)
         self._props.set_bool('keep-alive', keep_alive)
+
+    def set_value(self, value: str | Step | None) -> None:
+        """Set the value of this element.
+
+        :param value: step name or `Step` element
+        """
+        super().set_value(cast('str | None', value.props['name'] if isinstance(value, Step) else value))
 
     def _value_to_model_value(self, value: Any) -> Any:
         return value.props['name'] if isinstance(value, Step) else value

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -37,7 +37,7 @@ class Table(FilterElement, component='table.js'):
                  selection: Literal[None, 'single', 'multiple'] = DEFAULT_PROP | None,
                  pagination: int | dict | None = None,
                  on_select: Handler[TableSelectionEventArguments] | None = None,
-                 on_pagination_change: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 on_pagination_change: Handler[ValueChangeEventArguments[dict]] | None = None,
                  ) -> None:
         """Table
 
@@ -130,7 +130,7 @@ class Table(FilterElement, component='table.js'):
         self._selection_handlers.append(callback)
         return self
 
-    def on_pagination_change(self, callback: Handler[ValueChangeEventArguments[Any]]) -> Self:
+    def on_pagination_change(self, callback: Handler[ValueChangeEventArguments[dict]]) -> Self:
         """Add a callback to be invoked when the pagination changes."""
         self._pagination_change_handlers.append(callback)
         return self

--- a/nicegui/elements/tabs.py
+++ b/nicegui/elements/tabs.py
@@ -11,11 +11,11 @@ from .mixins.label_element import LabelElement
 from .mixins.value_element import ValueElement
 
 
-class Tabs(ValueElement[Any]):
+class Tabs(ValueElement[str | None]):
 
     def __init__(self, *,
                  value: Tab | TabPanel | None = None,
-                 on_change: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 on_change: Handler[ValueChangeEventArguments[str | None]] | None = None,
                  ) -> None:
         """Tabs
 
@@ -25,7 +25,15 @@ class Tabs(ValueElement[Any]):
         :param value: `ui.tab`, `ui.tab_panel`, or name of the tab to be initially selected
         :param on_change: callback to be executed when the selected tab changes (*since version 3.6.0*: event ``value`` is the tab name)
         """
-        super().__init__(tag='q-tabs', value=value, on_value_change=on_change)
+        _value = value.props['name'] if isinstance(value, (Tab, TabPanel)) else value
+        super().__init__(tag='q-tabs', value=_value, on_value_change=on_change)
+
+    def set_value(self, value: Tab | TabPanel | str | None) -> None:
+        """Set the value of this element.
+
+        :param value: tab name, `Tab` element, or `TabPanel` element
+        """
+        super().set_value(value.props['name'] if isinstance(value, (Tab, TabPanel)) else value)
 
     def _value_to_model_value(self, value: Any) -> Any:
         return value.props['name'] if isinstance(value, (Tab, TabPanel)) else value
@@ -59,13 +67,13 @@ class Tab(LabelElement, IconElement, DisableableElement):
                               'This will raise an error in NiceGUI 4.0.')
 
 
-class TabPanels(ValueElement[Any]):
+class TabPanels(ValueElement[str | None]):
 
     @resolve_defaults
     def __init__(self,
                  tabs: Tabs | None = None, *,
                  value: Tab | TabPanel | str | None = None,
-                 on_change: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 on_change: Handler[ValueChangeEventArguments[str | None]] | None = None,
                  animated: bool = DEFAULT_PROP | True,
                  keep_alive: bool = DEFAULT_PROP | True,
                  ) -> None:
@@ -84,11 +92,19 @@ class TabPanels(ValueElement[Any]):
         :param animated: whether the tab panels should be animated (default: `True`)
         :param keep_alive: whether to use Vue's keep-alive component on the content (default: `True`)
         """
-        super().__init__(tag='q-tab-panels', value=value, on_value_change=on_change)
+        _value = value.props['name'] if isinstance(value, (Tab, TabPanel)) else value
+        super().__init__(tag='q-tab-panels', value=_value, on_value_change=on_change)
         if tabs is not None:
             tabs.bind_value(self, 'value')
         self._props.set_bool('animated', animated)
         self._props.set_bool('keep-alive', keep_alive)
+
+    def set_value(self, value: Tab | TabPanel | str | None) -> None:
+        """Set the value of this element.
+
+        :param value: tab name, `Tab` element, or `TabPanel` element
+        """
+        super().set_value(value.props['name'] if isinstance(value, (Tab, TabPanel)) else value)
 
     def _value_to_model_value(self, value: Any) -> Any:
         return value.props['name'] if isinstance(value, (Tab, TabPanel)) else value

--- a/nicegui/elements/time_input.py
+++ b/nicegui/elements/time_input.py
@@ -1,5 +1,5 @@
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
+from ..events import Handler, ValueChangeEventArguments
 from .button import Button as button
 from .menu import Menu as menu
 from .mixins.disableable_element import DisableableElement
@@ -8,7 +8,7 @@ from .mixins.value_element import ValueElement
 from .time import Time as time
 
 
-class TimeInput(LabelElement, ValueElement[str], DisableableElement):
+class TimeInput(LabelElement, ValueElement[str | None], DisableableElement):
     LOOPBACK = False
 
     @resolve_defaults
@@ -39,6 +39,3 @@ class TimeInput(LabelElement, ValueElement[str], DisableableElement):
                     self.picker = time()
 
         self.picker.bind_value(self)
-
-    def _event_args_to_value(self, e: GenericEventArguments) -> str:
-        return e.args if e.args is not None else ''

--- a/nicegui/elements/time_input.py
+++ b/nicegui/elements/time_input.py
@@ -1,5 +1,5 @@
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import Handler, ValueChangeEventArguments
+from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .button import Button as button
 from .menu import Menu as menu
 from .mixins.disableable_element import DisableableElement
@@ -39,3 +39,6 @@ class TimeInput(LabelElement, ValueElement[str], DisableableElement):
                     self.picker = time()
 
         self.picker.bind_value(self)
+
+    def _event_args_to_value(self, e: GenericEventArguments) -> str:
+        return e.args if e.args is not None else ''

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -16,9 +16,9 @@ class Tree(FilterElement):
                  node_key: str = DEFAULT_PROP | 'id',
                  label_key: str = DEFAULT_PROP | 'label',
                  children_key: str = DEFAULT_PROP | 'children',
-                 on_select: Handler[ValueChangeEventArguments[Any]] | None = None,
-                 on_expand: Handler[ValueChangeEventArguments[Any]] | None = None,
-                 on_tick: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 on_select: Handler[ValueChangeEventArguments[str | None]] | None = None,
+                 on_expand: Handler[ValueChangeEventArguments[list[str]]] | None = None,
+                 on_tick: Handler[ValueChangeEventArguments[list[str]]] | None = None,
                  tick_strategy: Literal['leaf', 'leaf-filtered', 'strict'] | None = DEFAULT_PROP | None,
                  ) -> None:
         """Tree
@@ -91,7 +91,7 @@ class Tree(FilterElement):
                 handle_event(handler, args)
         self.on('update:ticked', handle_ticked)
 
-    def on_select(self, callback: Handler[ValueChangeEventArguments[Any]]) -> Self:
+    def on_select(self, callback: Handler[ValueChangeEventArguments[str | None]]) -> Self:
         """Add a callback to be invoked when the selection changes."""
         self._props.setdefault('selected', None)
         self._select_handlers.append(callback)
@@ -111,13 +111,13 @@ class Tree(FilterElement):
         """Remove node selection."""
         return self.select(None)
 
-    def on_expand(self, callback: Handler[ValueChangeEventArguments[Any]]) -> Self:
+    def on_expand(self, callback: Handler[ValueChangeEventArguments[list[str]]]) -> Self:
         """Add a callback to be invoked when the expansion changes."""
         self._props.setdefault('expanded', [])
         self._expand_handlers.append(callback)
         return self
 
-    def on_tick(self, callback: Handler[ValueChangeEventArguments[Any]]) -> Self:
+    def on_tick(self, callback: Handler[ValueChangeEventArguments[list[str]]]) -> Self:
         """Add a callback to be invoked when a node is ticked or unticked."""
         self._props.setdefault('ticked', [])
         self._props.setdefault('tick-strategy', 'leaf')


### PR DESCRIPTION
## Summary
- Rename TypeVar `V` to `ValueT`, import from `events.py` for cross-module consistency
- `Carousel`/`Stepper`/`Tabs`/`TabPanels`: `ValueElement[str | None]` with `set_value` overrides accepting element types
- `Tree`: concrete types — `on_select: str | None`, `on_expand/on_tick: list[str]`
- `Table`: concrete type — `on_pagination_change: dict`
- `Input`/`ColorInput`/`DateInput`/`TimeInput`/`Editor`: coerce `None` → `''` in `_event_args_to_value` (Quasar sends null on clearable clear)
- Item #4 (default `''` vs `None`) deferred to NiceGUI 4.0 per reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)