### PR TITLE
Address review feedback for #5889 (markdown support)

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -153,6 +153,8 @@ class Client:
     def build_response(self, request: Request, status_code: int = 200) -> Response:
         """Build a FastAPI response for the client."""
         accept = request.headers.get('accept', '')
+        # NOTE: This simple check doesn't handle quality values (q=) or wildcards (*/*).
+        # It works for the real use case: agents sending exactly `Accept: text/markdown`.
         if 'text/markdown' in accept and 'text/html' not in accept:
             response = build_markdown_response(self, status_code)
             background_tasks.create(self._deferred_delete(), name=f'delete markdown client {self.id}')

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -45,6 +45,8 @@ class Element(Visibility):
     _default_props: ClassVar[dict[str, Any]] = {}
     _default_classes: ClassVar[list[str]] = []
     _default_style: ClassVar[dict[str, str]] = {}
+    MARKDOWN_SKIP: bool = False
+    '''Set to True on non-visual elements (timers, keyboard handlers, etc.) to exclude from markdown output.'''
 
     def __init__(self, tag: str | None = None, *, _client: Client | None = None) -> None:
         """Generic Element
@@ -212,26 +214,37 @@ class Element(Visibility):
             if slot != self.default_slot
         }
 
-    MARKDOWN_SKIP: bool = False
-    '''Set to True on non-visual elements (timers, keyboard handlers, etc.) to exclude from markdown output.'''
-
     def _to_markdown(self) -> str:
-        """Convert this element to a markdown representation."""
+        """Convert this element to a markdown representation.
+
+        Subclasses should override ``_render_markdown`` instead of this method.
+        """
         if not self.visible or self.MARKDOWN_SKIP:
             return ''
+        return self._render_markdown()
+
+    def _render_markdown(self) -> str:
+        """Return the markdown body for this element.
+
+        Override in subclasses to customise the markdown output.
+        The visibility / MARKDOWN_SKIP guard is already handled by ``_to_markdown``.
+        """
         # Content elements (Markdown, Html, Mermaid)
         if hasattr(self, 'content') and isinstance(self.content, str):  # pylint: disable=no-member
             return self.content or ''  # pylint: disable=no-member
         # Text elements (Label, Badge, Chip)
         if self._text is not None:
             return self._text
-        # Label+Value elements (Input, Select, Number, DateInput, ...)
+        # Label+Value form elements (Input, Select, Number, Textarea, ...)
+        # Only match when the value is a simple displayable type to avoid misleading output
+        # from layout/value elements like Drawer, Carousel, etc. (whose value is not text).
         if hasattr(self, 'label') and hasattr(self, 'value'):
-            label = self.label or ''
-            value = self.value
-            if isinstance(value, list):
-                value = ', '.join(str(v) for v in value)
-            return f'{label}: {value}' if label else str(value or '')
+            value = self.value  # pylint: disable=no-member
+            if isinstance(value, (str, int, float)) or (isinstance(value, list) and all(isinstance(v, (str, int, float)) for v in value)):
+                label = self.label or ''  # pylint: disable=no-member
+                if isinstance(value, list):
+                    value = ', '.join(str(v) for v in value)
+                return f'{label}: {value}' if label else str(value if value != '' else '')
         # Recurse into children
         return self._children_to_markdown()
 

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -43,11 +43,12 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
         self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
+    def _render_markdown(self) -> str:
         label = self._props.get('label', '')
-        return f'[{label}]' if label else ''
+        if label:
+            return f'[Button: {label}]'
+        icon = self._props.get('icon', '')
+        return f'[Button: icon:{icon}]' if icon else ''
 
     def _text_to_model_text(self, text: str) -> None:
         self._props['label'] = text

--- a/nicegui/elements/carousel.py
+++ b/nicegui/elements/carousel.py
@@ -35,6 +35,9 @@ class Carousel(ValueElement):
         self._props['arrows'] = arrows
         self._props['navigation'] = navigation
 
+    def _render_markdown(self) -> str:
+        return self._children_to_markdown()
+
     def _value_to_model_value(self, value: Any) -> Any:
         return value.props['name'] if isinstance(value, CarouselSlide) else value
 

--- a/nicegui/elements/chat_message.py
+++ b/nicegui/elements/chat_message.py
@@ -46,6 +46,7 @@ class ChatMessage(LabelElement):
             text = []
         if isinstance(text, str):
             text = [text]
+        self._original_text = list(text)  # store before HTML escaping for lossless markdown roundtrip
         if not text_html:
             text = [html.escape(part) for part in text]
             text = [part.replace('\n', '<br />') for part in text]
@@ -55,15 +56,12 @@ class ChatMessage(LabelElement):
         self._props.set_optional('stamp', stamp)
         self._props.set_optional('avatar', avatar)
         self._props['sent'] = sent
-        self._markdown_text = text
 
         with self:
             for line in text:
                 Html(line, sanitize=sanitize)
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
+    def _render_markdown(self) -> str:
         name = self._props.get('name', '')
-        text = '\n'.join(html.unescape(line).replace('<br />', '\n') for line in self._markdown_text)
+        text = '\n'.join(self._original_text)
         return f'**{name}**: {text}' if name else text

--- a/nicegui/elements/checkbox.py
+++ b/nicegui/elements/checkbox.py
@@ -22,9 +22,5 @@ class Checkbox(TextElement, ValueElement, DisableableElement):
         """
         super().__init__(tag='q-checkbox', text=text, value=value, on_value_change=on_change)
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
-        check = 'x' if self.value else ' '
-        text = self._text or ''
-        return f'- [{check}] {text}'
+    def _render_markdown(self) -> str:
+        return f'- [{"x" if self.value else " "}] {self._text or ""}'

--- a/nicegui/elements/choice_element.py
+++ b/nicegui/elements/choice_element.py
@@ -21,6 +21,26 @@ class ChoiceElement(ValueElement):
         super().__init__(tag=tag, value=value, on_value_change=on_change)
         self._update_options()
 
+    def _render_markdown(self) -> str:
+        value = self.value
+        if value is None:
+            return ''
+        if isinstance(value, list):
+            display_labels = []
+            for v in value:
+                try:
+                    display_labels.append(str(self._labels[self._values.index(v)]))
+                except (ValueError, IndexError):
+                    display_labels.append(str(v))
+            display = ', '.join(display_labels)
+        else:
+            try:
+                display = str(self._labels[self._values.index(value)])
+            except (ValueError, IndexError):
+                display = str(value)
+        form_label = getattr(self, 'label', None) or ''
+        return f'{form_label}: {display}' if form_label else display
+
     def _update_values_and_labels(self) -> None:
         self._values = self.options if isinstance(self.options, list) else list(self.options.keys())
         self._labels = self.options if isinstance(self.options, list) else list(self.options.values())

--- a/nicegui/elements/code.py
+++ b/nicegui/elements/code.py
@@ -48,11 +48,8 @@ class Code(ContentElement, component='code.js', default_classes='nicegui-code'):
     def _update_copy_button(self) -> None:
         self.copy_button.set_visibility(time.time() > self._last_scroll + 1.0)
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
-        lang = self._language or ''
-        return f'```{lang}\n{self.content}\n```'
+    def _render_markdown(self) -> str:
+        return f'```{self._language or ""}\n{self.content}\n```'
 
     def _handle_content_change(self, content: str) -> None:
         self._props['content'] = content

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -9,7 +9,6 @@ from .mixins.value_element import ValueElement
 
 
 class Dialog(ValueElement, component='dialog.js'):
-    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self, *, value: bool = DEFAULT_PROPS['model-value'] | False) -> None:
@@ -66,6 +65,9 @@ class Dialog(ValueElement, component='dialog.js'):
         """Submit the dialog with the given result."""
         self._result = result
         self.submitted.set()
+
+    def _render_markdown(self) -> str:
+        return self._children_to_markdown() if self.value else ''
 
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)

--- a/nicegui/elements/drawer.py
+++ b/nicegui/elements/drawer.py
@@ -77,6 +77,9 @@ class Drawer(ValueElement, default_classes='nicegui-drawer'):
         """Hide the drawer"""
         self.value = False
 
+    def _render_markdown(self) -> str:
+        return self._children_to_markdown()
+
     def _handle_value_change(self, value: bool) -> None:
         super()._handle_value_change(value)
         self._props['show-if-above'] = value is None

--- a/nicegui/elements/expansion.py
+++ b/nicegui/elements/expansion.py
@@ -41,13 +41,11 @@ class Expansion(IconElement, TextElement, ValueElement, DisableableElement,
         """Close the expansion."""
         self.value = False
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
+    def _render_markdown(self) -> str:
         parts = []
         label = self._props.get('label', '')
         if label:
-            parts.append(f'### {label}')
+            parts.append(f'**{label}**')
         children_md = self._children_to_markdown()
         if children_md:
             parts.append(children_md)

--- a/nicegui/elements/footer.py
+++ b/nicegui/elements/footer.py
@@ -42,6 +42,9 @@ class Footer(ValueElement, default_classes='nicegui-footer'):
 
         self.move(target_index=-1)
 
+    def _render_markdown(self) -> str:
+        return self._children_to_markdown()
+
     def toggle(self) -> None:
         """Toggle the footer"""
         self.value = not self.value

--- a/nicegui/elements/fullscreen.py
+++ b/nicegui/elements/fullscreen.py
@@ -4,6 +4,7 @@ from .mixins.value_element import ValueElement
 
 
 class Fullscreen(ValueElement, component='fullscreen.js'):
+    MARKDOWN_SKIP = True
     LOOPBACK = None
 
     @resolve_defaults

--- a/nicegui/elements/image.py
+++ b/nicegui/elements/image.py
@@ -35,11 +35,8 @@ class Image(SourceElement, component='image.js'):
             source = pil_to_tempfile(source, self.PIL_CONVERT_FORMAT)
         super()._set_props(source)
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
-        src = self._props.get('src', '')
-        return f'![]({src})'
+    def _render_markdown(self) -> str:
+        return f'![]({self._props.get("src", "")})'
 
     def force_reload(self) -> None:
         """Force the image to reload from the source."""

--- a/nicegui/elements/knob.py
+++ b/nicegui/elements/knob.py
@@ -7,6 +7,7 @@ from .mixins.value_element import ValueElement
 
 
 class Knob(ValueElement, DisableableElement, TextColorElement):
+    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self,

--- a/nicegui/elements/link.py
+++ b/nicegui/elements/link.py
@@ -33,12 +33,8 @@ class Link(TextElement, component='link.js', default_classes='nicegui-link'):
             self._props['href'] = Client.page_routes[target]
         self._props['target'] = '_blank' if new_tab else '_self'
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
-        text = self._text or ''
-        href = self._props.get('href', '#')
-        return f'[{text}]({href})'
+    def _render_markdown(self) -> str:
+        return f'[{self._text or ""}]({self._props.get("href", "#")})'
 
 
 class LinkTarget(Element):

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -6,7 +6,6 @@ from .mixins.value_element import ValueElement
 
 
 class Menu(ValueElement):
-    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self, *, value: bool = DEFAULT_PROPS['model-value'] | False) -> None:
@@ -26,6 +25,9 @@ class Menu(ValueElement):
         self._props.add_warning('touch-position',
                                 'The prop "touch-position" is not supported by `ui.menu`. '
                                 'Use "ui.context_menu()" instead.')
+
+    def _render_markdown(self) -> str:
+        return self._children_to_markdown() if self.value else ''
 
     def open(self) -> None:
         """Open the menu."""

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -28,7 +28,9 @@ NotificationType: TypeAlias = Literal[
 
 
 class Notification(Element, component='notification.js'):
-    MARKDOWN_SKIP = True
+
+    def _render_markdown(self) -> str:
+        return str(self._props.get('options', {}).get('message', ''))
 
     def __init__(self,
                  message: Any = '', *,

--- a/nicegui/elements/pagination.py
+++ b/nicegui/elements/pagination.py
@@ -5,6 +5,7 @@ from .mixins.value_element import ValueElement
 
 
 class Pagination(ValueElement, DisableableElement):
+    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self,

--- a/nicegui/elements/progress.py
+++ b/nicegui/elements/progress.py
@@ -5,6 +5,7 @@ from .mixins.value_element import ValueElement
 
 
 class LinearProgress(ValueElement, TextColorElement):
+    MARKDOWN_SKIP = True
     VALUE_PROP = 'value'
 
     @resolve_defaults
@@ -33,6 +34,7 @@ class LinearProgress(ValueElement, TextColorElement):
 
 
 class CircularProgress(ValueElement, TextColorElement):
+    MARKDOWN_SKIP = True
     VALUE_PROP = 'value'
 
     @resolve_defaults

--- a/nicegui/elements/rating.py
+++ b/nicegui/elements/rating.py
@@ -5,6 +5,7 @@ from .mixins.value_element import ValueElement
 
 
 class Rating(ValueElement, DisableableElement):
+    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self,

--- a/nicegui/elements/scroll_area.py
+++ b/nicegui/elements/scroll_area.py
@@ -21,6 +21,9 @@ class ScrollArea(Element, default_classes='nicegui-scroll-area'):
         if on_scroll:
             self.on_scroll(on_scroll)
 
+    def _render_markdown(self) -> str:
+        return self._children_to_markdown()
+
     def on_scroll(self, callback: Handler[ScrollEventArguments]) -> Self:
         """Add a callback to be invoked when the scroll position changes."""
         self.on('scroll', lambda e: self._handle_scroll(callback, e), args=[

--- a/nicegui/elements/separator.py
+++ b/nicegui/elements/separator.py
@@ -12,7 +12,5 @@ class Separator(Element, default_classes='nicegui-separator'):
         """
         super().__init__('q-separator')
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
+    def _render_markdown(self) -> str:
         return '---'

--- a/nicegui/elements/slider.py
+++ b/nicegui/elements/slider.py
@@ -5,6 +5,7 @@ from .mixins.value_element import ValueElement
 
 
 class Slider(ValueElement, DisableableElement):
+    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self, *,

--- a/nicegui/elements/splitter.py
+++ b/nicegui/elements/splitter.py
@@ -39,3 +39,6 @@ class Splitter(ValueElement, DisableableElement, default_classes='nicegui-splitt
         self.before = self.add_slot('before')
         self.after = self.add_slot('after')
         self.separator = self.add_slot('separator')
+
+    def _render_markdown(self) -> str:
+        return self._children_to_markdown()

--- a/nicegui/elements/switch.py
+++ b/nicegui/elements/switch.py
@@ -22,9 +22,5 @@ class Switch(TextElement, ValueElement, DisableableElement):
         """
         super().__init__(tag='q-toggle', text=text, value=value, on_value_change=on_change)
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
-        check = 'x' if self.value else ' '
-        text = self._text or ''
-        return f'- [{check}] {text}'
+    def _render_markdown(self) -> str:
+        return f'- [{"x" if self.value else " "}] {self._text or ""}'

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -125,9 +125,7 @@ class Table(FilterElement, component='table.js'):
 
         return super()._to_dict()
 
-    def _to_markdown(self) -> str:
-        if not self.visible:
-            return ''
+    def _render_markdown(self) -> str:
         columns = self._props.get('columns', [])
         rows = self._props.get('rows', [])
         title = self._props.get('title')

--- a/nicegui/markdown_response.py
+++ b/nicegui/markdown_response.py
@@ -22,5 +22,10 @@ def build_markdown_response(client: Client, status_code: int = 200) -> Response:
         content=content,
         media_type='text/markdown; charset=utf-8',
         status_code=status_code,
-        headers={'Cache-Control': 'no-store', 'X-NiceGUI-Content': 'page'},
+        headers={
+            'Cache-Control': 'no-store',
+            # X-NiceGUI-Content lets clients programmatically distinguish NiceGUI page responses
+            # from other responses (e.g. static files, API endpoints) without parsing the body.
+            'X-NiceGUI-Content': 'page',
+        },
     )

--- a/tests/test_markdown_response.py
+++ b/tests/test_markdown_response.py
@@ -103,7 +103,7 @@ async def test_button(user: User):
         ui.button('Click me')
 
     response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
-    assert '[Click me]' in response.text
+    assert '[Button: Click me]' in response.text
 
 
 async def test_code_element(user: User):
@@ -133,7 +133,7 @@ async def test_expansion(user: User):
             ui.label('Hidden content')
 
     response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
-    assert '### Details' in response.text
+    assert '**Details**' in response.text
     assert 'Hidden content' in response.text
 
 
@@ -205,7 +205,8 @@ async def test_chat_message(user: User):
     assert 'Hello there!' in response.text
 
 
-async def test_dialog_skipped(user: User):
+async def test_dialog_closed(user: User):
+    """Closed dialog should not render children."""
     @ui.page('/')
     def page():
         with ui.dialog():
@@ -215,6 +216,19 @@ async def test_dialog_skipped(user: User):
     response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
     assert 'Visible' in response.text
     assert 'Secret' not in response.text
+
+
+async def test_dialog_open(user: User):
+    """Open dialog should render children."""
+    @ui.page('/')
+    def page():
+        with ui.dialog(value=True):
+            ui.label('Dialog content')
+        ui.label('Visible')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'Dialog content' in response.text
+    assert 'Visible' in response.text
 
 
 async def test_context_menu_skipped(user: User):
@@ -252,3 +266,138 @@ async def test_invisible_elements_excluded(user: User):
     response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
     assert 'Visible' in response.text
     assert 'Hidden' not in response.text
+
+
+
+async def test_select_with_label(user: User):
+    @ui.page('/')
+    def page():
+        ui.select(['A', 'B', 'C'], label='Choice', value='B')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'Choice' in response.text
+    assert 'B' in response.text
+
+
+async def test_select_without_label(user: User):
+    @ui.page('/')
+    def page():
+        ui.select(['A', 'B', 'C'], value='B')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'B' in response.text
+
+
+async def test_radio(user: User):
+    @ui.page('/')
+    def page():
+        ui.radio(['X', 'Y', 'Z'], value='Y')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'Y' in response.text
+
+
+async def test_slider_skipped(user: User):
+    """Slider should be skipped (MARKDOWN_SKIP)."""
+    @ui.page('/')
+    def page():
+        ui.slider(min=0, max=100, value=50)
+        ui.label('After slider')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'After slider' in response.text
+    assert '50' not in response.text
+
+
+async def test_number_without_label(user: User):
+    @ui.page('/')
+    def page():
+        ui.number(value=42)
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert '42' in response.text
+
+
+async def test_badge(user: User):
+    @ui.page('/')
+    def page():
+        ui.badge('NEW')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'NEW' in response.text
+
+
+async def test_chip(user: User):
+    @ui.page('/')
+    def page():
+        ui.chip('Tag')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'Tag' in response.text
+
+
+async def test_html_element(user: User):
+    @ui.page('/')
+    def page():
+        ui.html('<b>Bold text</b>')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert '<b>Bold text</b>' in response.text
+
+
+async def test_menu_closed(user: User):
+    """Closed menu should not render children."""
+    @ui.page('/')
+    def page():
+        with ui.button('Menu button'):
+            with ui.menu():
+                ui.menu_item('Item 1')
+        ui.label('Visible')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'Visible' in response.text
+    assert 'Item 1' not in response.text
+
+
+async def test_menu_open(user: User):
+    """Open menu should render children."""
+    @ui.page('/')
+    def page():
+        with ui.column():
+            with ui.menu(value=True):
+                ui.menu_item('Item 1')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'Item 1' in response.text
+
+
+async def test_notification(user: User):
+    """Notification should render its message."""
+    @ui.page('/')
+    def page():
+        ui.notification('Hello notification!')
+        ui.label('Page content')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert 'Hello notification!' in response.text
+    assert 'Page content' in response.text
+
+
+async def test_button_icon_only(user: User):
+    """Icon-only button should show icon name."""
+    @ui.page('/')
+    def page():
+        ui.button(icon='thumb_up')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert '[Button: icon:thumb_up]' in response.text
+
+
+async def test_x_nicegui_content_header(user: User):
+    """Markdown response should include X-NiceGUI-Content header."""
+    @ui.page('/')
+    def page():
+        ui.label('Hello')
+
+    response = await user.http_client.get('/', headers=MARKDOWN_ACCEPT)
+    assert response.headers.get('X-NiceGUI-Content') == 'page'


### PR DESCRIPTION
## Summary
All 12 review items from @falkoschindler addressed:

- **Template method**: `_to_markdown()` guards visibility/skip, subclasses override `_render_markdown()`
- **ChatMessage**: stores original text before escaping (fixes lossy roundtrip)
- **Dialog/Menu**: render children only when open (not unconditional MARKDOWN_SKIP)
- **Notification**: renders message text instead of skipping
- **Fullscreen**: `MARKDOWN_SKIP = True`
- **Button**: `[Button: label]` syntax, icon-only fallback `[Button: icon:name]`
- **Expansion**: bold instead of h3
- **Containers**: recurse children only (Drawer, Footer, ScrollArea, Carousel, Splitter)
- **Value widgets**: MARKDOWN_SKIP for Slider, Knob, Rating, Pagination, Progress
- **ChoiceElement**: resolve selected value to display label
- **Accept header**: comment noting simplistic parsing
- **X-NiceGUI-Content**: comment explaining purpose
- **15 new tests** covering select, radio, badge, chip, html, dialog, menu, notification, icon-only button

🤖 Generated with [Claude Code](https://claude.com/claude-code)