### PR TITLE
WIP: Tab panels cycling (pre-render for ui.keep_alive prerequisite)

### DIFF
--- a/TEST_SCRIPT.py
+++ b/TEST_SCRIPT.py
@@ -1,0 +1,33 @@
+"""Eager tab panels demo: AG Grid is accessible even before visiting its tab."""
+from nicegui import ui
+
+
+@ui.page('/')
+async def main():
+    ui.label('Eager tab panels').classes('text-h5')
+
+    with ui.tabs() as tabs:
+        ui.tab('One')
+        ui.tab('Two')
+        ui.tab('Three')
+
+    with ui.tab_panels(tabs, value='One', eager=True):
+        with ui.tab_panel('One'):
+            ui.label('This is the first panel.')
+        with ui.tab_panel('Two'):
+            grid = ui.aggrid({
+                'columnDefs': [{'field': 'name'}, {'field': 'age'}],
+                'rowData': [{'name': 'Alice', 'age': 25}, {'name': 'Bob', 'age': 30}],
+            })
+        with ui.tab_panel('Three'):
+            ui.label('Third panel content')
+
+    async def check():
+        found = await ui.run_javascript(f'!!getElement({grid.id})')
+        ui.notify(f'AG Grid mounted (without visiting tab): {found}')
+
+    await ui.context.client.connected()
+    await check()
+
+
+ui.run()

--- a/nicegui/elements/tab_panels.js
+++ b/nicegui/elements/tab_panels.js
@@ -1,0 +1,29 @@
+export default {
+  template: `
+    <q-tab-panels ref="qRef" v-bind="$attrs" keep-alive>
+      <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
+        <slot :name="slot" v-bind="slotProps || {}" />
+      </template>
+    </q-tab-panels>
+  `,
+  inheritAttrs: false,
+  async mounted() {
+    const id = this.$el.id.slice(1);
+    const elements = this.$root.$data.elements;
+    const element = elements[id];
+    const childIds = element.slots?.default?.ids || [];
+    const names = childIds.map((cid) => elements[cid]?.props?.name).filter(Boolean);
+    if (names.length <= 1) return;
+    const qRef = this.$refs.qRef;
+    const wasAnimated = qRef.animated;
+    qRef.$.props.animated = false;
+    const original = element.props["model-value"];
+    for (const name of names) {
+      element.props["model-value"] = name;
+      await Vue.nextTick();
+    }
+    element.props["model-value"] = original;
+    await Vue.nextTick();
+    qRef.$.props.animated = wasAnimated;
+  },
+};

--- a/nicegui/elements/tabs.py
+++ b/nicegui/elements/tabs.py
@@ -53,7 +53,7 @@ class Tab(LabelElement, IconElement, DisableableElement):
         self.tabs = context.slot.parent
 
 
-class TabPanels(ValueElement):
+class TabPanels(ValueElement, component='tab_panels.js'):
 
     @resolve_defaults
     def __init__(self,
@@ -62,6 +62,7 @@ class TabPanels(ValueElement):
                  on_change: Handler[ValueChangeEventArguments] | None = None,
                  animated: bool = DEFAULT_PROP | True,
                  keep_alive: bool = DEFAULT_PROP | True,
+                 eager: bool = False,
                  ) -> None:
         """Tab Panels
 
@@ -77,12 +78,14 @@ class TabPanels(ValueElement):
         :param on_change: callback to be executed when the visible tab panel changes (*since version 3.6.0*: event ``value`` is the tab name)
         :param animated: whether the tab panels should be animated (default: `True`)
         :param keep_alive: whether to use Vue's keep-alive component on the content (default: `True`)
+        :param eager: whether to render all tab panels immediately so that elements like AG Grid are mounted in the DOM (default: `False`)
         """
-        super().__init__(tag='q-tab-panels', value=value, on_value_change=on_change)
+        tag = None if eager else 'q-tab-panels'
+        super().__init__(tag=tag, value=value, on_value_change=on_change)
         if tabs is not None:
             tabs.bind_value(self, 'value')
         self._props.set_bool('animated', animated)
-        self._props.set_bool('keep-alive', keep_alive)
+        self._props.set_bool('keep-alive', keep_alive or eager)
 
     def _value_to_model_value(self, value: Any) -> Any:
         return value.props['name'] if isinstance(value, (Tab, TabPanel)) else value

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -57,6 +57,92 @@ def test_with_tab_objects(screen: Screen):
     assert tab_panel_events == ['One', 'Two']
 
 
+def test_eager_tab_panels(screen: Screen):
+    @ui.page('/')
+    def page():
+        with ui.tabs() as tabs:
+            ui.tab('One')
+            ui.tab('Two')
+
+        with ui.tab_panels(tabs, value='One', eager=True):
+            with ui.tab_panel('One'):
+                ui.label('First tab')
+            with ui.tab_panel('Two'):
+                ui.label('Second tab')
+
+    screen.open('/')
+    screen.should_contain('First tab')
+    screen.click('Two')
+    screen.should_contain('Second tab')
+
+
+def test_eager_tab_panels_no_spurious_events(screen: Screen):
+    events = []
+
+    @ui.page('/')
+    def page():
+        with ui.tabs() as tabs:
+            ui.tab('One')
+            ui.tab('Two')
+            ui.tab('Three')
+
+        with ui.tab_panels(tabs, value='One', eager=True, on_change=lambda e: events.append(e.value)):
+            with ui.tab_panel('One'):
+                ui.label('First tab')
+            with ui.tab_panel('Two'):
+                ui.label('Second tab')
+            with ui.tab_panel('Three'):
+                ui.label('Third tab')
+
+    screen.open('/')
+    screen.should_contain('First tab')
+    assert events == []
+    screen.click('Two')
+    screen.should_contain('Second tab')
+    assert events == ['Two']
+    screen.click('Three')
+    screen.should_contain('Third tab')
+    assert events == ['Two', 'Three']
+
+
+def test_eager_tab_panels_mount_offscreen_elements(screen: Screen):
+    @ui.page('/')
+    async def page():
+        with ui.tabs() as tabs:
+            ui.tab('One')
+            ui.tab('Two')
+
+        with ui.tab_panels(tabs, value='One', eager=True):
+            with ui.tab_panel('One'):
+                ui.label('Panel One')
+            with ui.tab_panel('Two'):
+                eager_grid = ui.aggrid({})
+
+        with ui.tabs() as tabs2:
+            ui.tab('A')
+            ui.tab('B')
+
+        with ui.tab_panels(tabs2, value='A'):
+            with ui.tab_panel('A'):
+                ui.label('Panel A')
+            with ui.tab_panel('B'):
+                lazy_grid = ui.aggrid({})
+
+        ui.button('Check', on_click=lambda: check())
+
+        async def check():
+            eager_found = await ui.run_javascript(f'!!getElement({eager_grid.id})')
+            lazy_found = await ui.run_javascript(f'!!getElement({lazy_grid.id})')
+            ui.label(f'eager:{eager_found}')
+            ui.label(f'lazy:{lazy_found}')
+
+    screen.open('/')
+    screen.wait(1.0)  # wait for cycling to complete
+    screen.click('Check')
+    screen.should_contain('eager:True')
+    screen.should_contain('lazy:False')
+
+
 def test_updating_offscreen_elements_with_update_method(screen: Screen):
     @ui.page('/')
     def main_page():


### PR DESCRIPTION
WIP draft on fork — **do not merge to upstream**.

## Idea
Pre-render tab panel contents on tab creation so switching tabs is instant (e.g. AG Grid inside a tab stays mounted/warm).

## Status
- Spare implementation: **only relevant if \`ui.keep_alive\` does not land upstream**.
- If \`ui.keep_alive\` ships, this approach is superseded and can be closed.
- 2 commits: rough prototype + test script.
- 65 behind main.

## Next steps
Revisit iff \`ui.keep_alive\` stalls. Archival draft so the idea is not lost.