### PR TITLE
Re-track: Accessibility enhancement on styles (ex-upstream #5795)

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,6 +58,7 @@ class custom_sub_pages(ui.sub_pages):
 @ui.page('/documentation/{path:path}')
 @ui.page('/imprint_privacy')
 def _main_page() -> None:
+    ui.colors(primary='#317ABE', at_rule='@media (prefers-contrast: more)')
     ui.context.client.content.classes('p-0 gap-0')
     header.add_head_html()
 

--- a/nicegui/elements/colors.js
+++ b/nicegui/elements/colors.js
@@ -1,15 +1,45 @@
 export default {
   mounted() {
-    document.body.style.setProperty("--q-primary", this.primary);
-    document.body.style.setProperty("--q-secondary", this.secondary);
-    document.body.style.setProperty("--q-accent", this.accent);
-    document.body.style.setProperty("--q-dark", this.dark);
-    document.body.style.setProperty("--q-dark-page", this.darkPage);
-    document.body.style.setProperty("--q-positive", this.positive);
-    document.body.style.setProperty("--q-negative", this.negative);
-    document.body.style.setProperty("--q-info", this.info);
-    document.body.style.setProperty("--q-warning", this.warning);
-    applyColors(this.customColors);
+    if (!this.atRule) {
+      document.body.style.setProperty("--q-primary", this.primary);
+      document.body.style.setProperty("--q-secondary", this.secondary);
+      document.body.style.setProperty("--q-accent", this.accent);
+      document.body.style.setProperty("--q-dark", this.dark);
+      document.body.style.setProperty("--q-dark-page", this.darkPage);
+      document.body.style.setProperty("--q-positive", this.positive);
+      document.body.style.setProperty("--q-negative", this.negative);
+      document.body.style.setProperty("--q-info", this.info);
+      document.body.style.setProperty("--q-warning", this.warning);
+      applyColors(this.customColors);
+      return;
+    }
+    const colors = {
+      "--q-primary": this.primary,
+      "--q-secondary": this.secondary,
+      "--q-accent": this.accent,
+      "--q-dark": this.dark,
+      "--q-dark-page": this.darkPage,
+      "--q-positive": this.positive,
+      "--q-negative": this.negative,
+      "--q-info": this.info,
+      "--q-warning": this.warning,
+    };
+    let css = Object.entries(colors)
+      .map(([k, v]) => `  body { ${k}: ${v} !important; }`)
+      .join("\n");
+    for (const [color, value] of Object.entries(this.customColors || {})) {
+      const name = color.replaceAll("_", "-");
+      const varName = "--q-" + name;
+      css += `\n  body { ${varName}: ${value} !important; }`;
+      css += `\n  .text-${name} { color: var(${varName}) !important; }`;
+      css += `\n  .bg-${name} { background-color: var(${varName}) !important; }`;
+    }
+    this.styleEl = document.createElement("style");
+    this.styleEl.innerHTML = `${this.atRule} {\n${css}\n}`;
+    document.head.appendChild(this.styleEl);
+  },
+  unmounted() {
+    this.styleEl?.remove();
   },
   props: {
     primary: String,
@@ -21,6 +51,7 @@ export default {
     negative: String,
     info: String,
     warning: String,
+    atRule: String,
     customColors: Object,
   },
 };

--- a/nicegui/elements/colors.py
+++ b/nicegui/elements/colors.py
@@ -16,6 +16,7 @@ class Colors(Element, component='colors.js'):
                  negative: str = DEFAULT_PROP | '#c10015',
                  info: str = DEFAULT_PROP | '#31ccec',
                  warning: str = DEFAULT_PROP | '#f2c037',
+                 at_rule: str = '',
                  **custom_colors: str) -> None:
         """Color Theming
 
@@ -32,6 +33,7 @@ class Colors(Element, component='colors.js'):
         :param negative: Negative color (default: "#c10015")
         :param info: Info color (default: "#31ccec")
         :param warning: Warning color (default: "#f2c037")
+        :param at_rule: CSS at-rule to limit when the colors apply (e.g. ``"@media (prefers-color-scheme: dark)"``)
         :param custom_colors: Custom color definitions for branding (needs ``ui.colors`` to be called before custom color is ever used, *added in version 2.2.0*)
         """
         super().__init__()
@@ -44,6 +46,7 @@ class Colors(Element, component='colors.js'):
         self._props['negative'] = negative
         self._props['info'] = info
         self._props['warning'] = warning
+        self._props['at-rule'] = at_rule
         self._props['custom-colors'] = custom_colors
         QUASAR_COLORS.update({name.replace('_', '-') for name in custom_colors})
 

--- a/nicegui/elements/sub_pages.js
+++ b/nicegui/elements/sub_pages.js
@@ -29,7 +29,7 @@ function handleFragmentNavigation(href, targetUrl) {
   const target = document.getElementById(fragmentName) || document.querySelector(`a[name="${fragmentName}"]`);
   if (!target) return false;
 
-  target.scrollIntoView({ behavior: "smooth" });
+  target.scrollIntoView();
   const cleanHref = stripPathPrefix(href);
   history.pushState({ page: cleanHref }, "", buildFullPath(cleanHref));
   return true;

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -88,7 +88,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             if match.remaining_path and not any(isinstance(el, SubPages) for el in self.descendants()):
                 self._set_match(None)
             else:
-                self._handle_scrolling(match, behavior='smooth')
+                self._handle_scrolling(match, behavior='auto')
                 self._set_match(match)
         else:
             self._cancel_active_tasks()

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -326,3 +326,11 @@ h6.q-timeline__title {
   position: absolute;
   right: 1.5em;
 }
+@media (prefers-reduced-motion: reduce) {
+  html,
+  body * {
+    transition: none !important;
+    animation: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -32,3 +32,13 @@ def test_replace_colors(screen: Screen):
     screen.click('Replace')
     screen.wait(0.5)
     assert screen.find_by_tag('button').value_of_css_property('background-color') == 'rgba(255, 0, 0, 1)'
+
+
+def test_at_rule(screen: Screen):
+    @ui.page('/')
+    def page():
+        ui.colors(primary='#ff0000', at_rule='@media (min-width: 0px)')
+        ui.button('Test Button')
+
+    screen.open('/')
+    assert screen.find_by_tag('button').value_of_css_property('background-color') == 'rgba(255, 0, 0, 1)'

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -147,7 +147,7 @@ def create_tiles():
     for documentation, description in tiles:
         page = doc.get_page(documentation)
         with ui.link(target=f'/documentation/{page.name}') \
-                .classes('bg-[#5898d420] p-4 self-stretch rounded flex flex-col gap-2') \
+                .classes('bg-primary-alpha p-4 self-stretch rounded flex flex-col gap-2') \
                 .style('box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1)'):
             if page.title:
                 ui.label(page.title.replace('*', '')).classes(replace='text-2xl')

--- a/website/documentation/demo.py
+++ b/website/documentation/demo.py
@@ -14,7 +14,7 @@ def demo(f: Callable, *, lazy: bool = True, tab: str | Callable | None = None) -
         with python_window(classes='w-full max-w-[44rem]'):
             ui.markdown(f'````python\n{full_code}\n````')
             ui.icon('content_copy', size='xs') \
-                .classes('absolute right-2 top-10 opacity-10 hover:opacity-80 cursor-pointer') \
+                .classes('absolute right-2 top-10 hover-opacity cursor-pointer') \
                 .on('click', js_handler=f'() => navigator.clipboard.writeText({json.dumps(full_code)})') \
                 .on('click', lambda: ui.notify('Copied to clipboard', type='positive', color='primary'), [])
         with browser_window(title=tab,

--- a/website/documentation/windows.py
+++ b/website/documentation/windows.py
@@ -23,9 +23,9 @@ def _window(type_: WindowType, *, title: str = '', tab: str | Callable = '', cla
     bar_color = ('#00000010', '#ffffff10')
     color = WINDOW_BG_COLORS[type_]
     with ui.card() \
-            .classes(f'no-wrap bg-[{color[0]}] dark:bg-[{color[1]}] rounded-xl overflow-hidden p-0 gap-0 {classes}') \
+            .classes(f'forced-colors:outline no-wrap bg-[{color[0]}] dark:bg-[{color[1]}] rounded-xl overflow-hidden p-0 gap-0 {classes}') \
             .style('box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1)'):
-        with ui.row().classes(f'w-full h-8 p-2 bg-[{bar_color[0]}] dark:bg-[{bar_color[1]}]'):
+        with ui.row().classes(f'forced-colors:outline w-full h-8 p-2 bg-[{bar_color[0]}] dark:bg-[{bar_color[1]}]'):
             _dots()
             if title:
                 ui.label(title) \
@@ -36,12 +36,12 @@ def _window(type_: WindowType, *, title: str = '', tab: str | Callable = '', cla
                     with ui.label().classes(f'w-2 h-[24px] bg-[{color[0]}] dark:bg-[{color[1]}]'):
                         ui.label().classes(
                             f'w-full h-full bg-[{bar_color[0]}] dark:bg-[{bar_color[1]}] rounded-br-[6px]')
-                    with ui.row().classes(f'text-sm text-gray-600 dark:text-gray-400 px-6 py-1 h-[24px] rounded-t-[6px] bg-[{color[0]}] dark:bg-[{color[1]}] items-center gap-2'):
+                    with ui.row().classes(f'forced-colors:outline text-sm text-gray-600 dark:text-gray-400 px-6 py-1 h-[24px] rounded-t-[6px] bg-[{color[0]}] dark:bg-[{color[1]}] items-center gap-2'):
                         if callable(tab):
                             tab()
                         else:
                             ui.label(tab)
-                    with ui.label().classes(f'w-2 h-[24px] bg-[{color[0]}] dark:bg-[{color[1]}]'):
+                    with ui.label().classes(f'forced-colors:hidden w-2 h-[24px] bg-[{color[0]}] dark:bg-[{color[1]}]'):
                         ui.label().classes(
                             f'w-full h-full bg-[{bar_color[0]}] dark:bg-[{bar_color[1]}] rounded-bl-[6px]')
         return ui.column().classes('w-full h-full overflow-auto')

--- a/website/header.py
+++ b/website/header.py
@@ -43,8 +43,8 @@ def add_header(menu: ui.left_drawer) -> ui.button:
             .style('box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1)'):
         menu_button = ui.button(on_click=menu.toggle, icon='menu').props('flat color=white round').classes('lg:hidden')
         with ui.link(target='/').classes('row gap-4 items-center no-wrap mr-auto'):
-            svg.face().classes('w-8 stroke-white stroke-2 max-[610px]:hidden')
-            svg.word().classes('w-24')
+            svg.face().classes('w-8 stroke-white forced-colors:invert stroke-2 max-[610px]:hidden')
+            svg.word().classes('w-24 forced-colors:invert')
 
         with ui.row().classes('max-[1050px]:hidden'):
             for title_, target in menu_items.items():
@@ -62,11 +62,11 @@ def add_header(menu: ui.left_drawer) -> ui.button:
                 .props('flat fab-mini color=white').bind_visibility_from(dark_mode, 'value', lambda mode: mode is None)
 
         with ui.link(target='https://discord.gg/TEpFeAaF4f').classes('max-[515px]:hidden').tooltip('Discord'):
-            svg.discord().classes('fill-white scale-125 m-1')
+            svg.discord().classes('fill-white forced-colors:invert scale-125 m-1')
         with ui.link(target='https://www.reddit.com/r/nicegui/').classes('max-[465px]:hidden').tooltip('Reddit'):
-            svg.reddit().classes('fill-white scale-125 m-1')
+            svg.reddit().classes('fill-white forced-colors:invert scale-125 m-1')
         with ui.link(target='https://github.com/zauberzeug/nicegui/').classes('max-[365px]:hidden').tooltip('GitHub'):
-            svg.github().classes('fill-white scale-125 m-1')
+            svg.github().classes('fill-white forced-colors:invert scale-125 m-1')
 
         add_star().classes('max-[550px]:hidden')
 

--- a/website/main_page.py
+++ b/website/main_page.py
@@ -234,6 +234,6 @@ def create() -> None:
                         [Uvicorn](https://www.uvicorn.org/)
                         because of their great performance and ease of use.
                     ''')
-            svg.face().classes('stroke-white shrink-0 w-[200px] md:w-[300px] lg:w-[450px]')
+            svg.face().classes('stroke-white forced-colors:invert shrink-0 w-[200px] md:w-[300px] lg:w-[450px]')
         with ui.column().classes('w-full p-4 items-end text-white self-end'):
             ui.link('Imprint & Privacy', '/imprint_privacy').classes('text-sm')

--- a/website/star.py
+++ b/website/star.py
@@ -35,7 +35,7 @@ STAR = '''
 def add_star() -> ui.link:
     ui.add_css(STYLE)
     with ui.link(target='https://github.com/zauberzeug/nicegui/').classes('star-container') as link:
-        with Element('svg').props('viewBox="0 0 24 24"').classes('star'):
+        with Element('svg').props('viewBox="0 0 24 24"').classes('star forced-colors:invert'):
             Element('path').props('d="M23.555,8.729a1.505,1.505,0,0,0-1.406-.98H16.062a.5.5,0,0,1-.472-.334L13.405,1.222a1.5,1.5,0,0,0-2.81,0l-.005.016L8.41,7.415a.5.5,0,0,1-.471.334H1.85A1.5,1.5,0,0,0,.887,10.4l5.184,4.3a.5.5,0,0,1,.155.543L4.048,21.774a1.5,1.5,0,0,0,2.31,1.684l5.346-3.92a.5.5,0,0,1,.591,0l5.344,3.919a1.5,1.5,0,0,0,2.312-1.683l-2.178-6.535a.5.5,0,0,1,.155-.543l5.194-4.306A1.5,1.5,0,0,0,23.555,8.729Z"')
         with ui.tooltip('').classes('bg-[#486991] w-96 p-4'):
             with ui.row().classes('items-center no-wrap'):

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -21,7 +21,7 @@ html {
 }
 .fancy-em em {
   font-style: normal;
-  color: #5898d4;
+  color: var(--q-primary);
 }
 a:link:not(.browser-window *),
 a:visited:not(.browser-window *) {
@@ -57,12 +57,12 @@ a:active:not(.browser-window *) {
 
 .q-header {
   height: 70px;
-  background-color: #5898d4;
+  background-color: var(--q-primary);
 }
 .q-header.fade {
   padding-top: 20px;
   transform: translateY(-20px);
-  background-color: #5898d4d0;
+  background-color: color-mix(in srgb, var(--q-primary) 82%, transparent);
   backdrop-filter: blur(5px);
 }
 .body--dark .q-header {
@@ -134,8 +134,12 @@ dl.docinfo p {
   margin: 0;
 }
 
+.bg-primary-alpha {
+  background-color: color-mix(in srgb, var(--q-primary) 12.5%, transparent);
+}
+
 .dark-box {
-  background-color: #5898d4;
+  background-color: var(--q-primary);
   width: 100%;
 }
 .body--dark .dark-box {

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -62,8 +62,12 @@ a:active:not(.browser-window *) {
 .q-header.fade {
   padding-top: 20px;
   transform: translateY(-20px);
-  background-color: color-mix(in srgb, var(--q-primary) 82%, transparent);
-  backdrop-filter: blur(5px);
+}
+@media (prefers-reduced-transparency: no-preference) {
+  .q-header.fade {
+    background-color: color-mix(in srgb, var(--q-primary) 82%, transparent);
+    backdrop-filter: blur(5px);
+  }
 }
 .body--dark .q-header {
   background-color: #3e6a94;

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -211,3 +211,17 @@ dl.docinfo p {
     /* Modern Browsers */ url("/fonts/fira-mono-v14-latin-regular.ttf") format("truetype"),
     /* Safari, Android, iOS */ url("/fonts/fira-mono-v14-latin-regular.svg#FiraMono") format("svg"); /* Legacy iOS */
 }
+.hover-opacity {
+  opacity: 10%;
+}
+.hover-opacity:hover {
+  opacity: 80%;
+}
+@media (forced-colors: active) {
+  .hover-opacity {
+    opacity: 60%;
+  }
+  .hover-opacity:hover {
+    opacity: 100%;
+  }
+}

--- a/website/style.py
+++ b/website/style.py
@@ -39,7 +39,7 @@ def subtitle(content: str) -> ui.markdown:
 def example_link(example: Example | None = None) -> ui.link:
     """Render a link to an example."""
     with ui.link(target=example.url if example else '/examples') \
-            .classes('bg-[#5898d420] p-4 self-stretch rounded flex flex-col gap-2') \
+            .classes('bg-primary-alpha p-4 self-stretch rounded flex flex-col gap-2') \
             .style('box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1)') as link:
         ui.label(example.title if example else '...and many more').classes(replace='font-bold')
         ui.markdown(example.description if example else 'Browse through plenty of examples.') \

--- a/website/style.py
+++ b/website/style.py
@@ -77,7 +77,7 @@ def subheading(text: str, *, link: str | None = None, major: bool = False, ancho
         else:
             ui.label(text).classes(classes)
         with ui.link(target=f'#{name}').classes('absolute').style('transform: translateX(-150%)'):
-            ui.icon('link', size='sm').classes('opacity-10 hover:opacity-80')
+            ui.icon('link', size='sm').classes('hover-opacity')
 
 
 def create_anchor_name(text: str) -> str:


### PR DESCRIPTION
Re-tracking on fork — former upstream PR [zauberzeug/nicegui#5795](https://github.com/zauberzeug/nicegui/pull/5795) closed because it predates website redesign #5910 (2026-03-25) and merge-conflicts on 9 now-rewritten files.

## Scope
Library-level and documentation-level accessibility improvements around styles (from [discussion #5794](https://github.com/zauberzeug/nicegui/discussions/5794)).

## Next steps before revival
1. Rebase onto current main (post-#5910 website).
2. Split into focused upstream PRs (library-level styles, doc-site adjustments, media-query additions).
3. Companion branch with \`forced-colors\`/\`prefers-reduced-motion\`/\`prefers-reduced-transparency\`: #109.

## Revive condition
Per-slice rebase complete + paired with a new doc section on \`@media\` + \`ui.colors(at_rule=...)\` pattern.