### PR TITLE
refactor: explicit _render_markdown per element

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -45,8 +45,6 @@ class Element(Visibility):
     _default_props: ClassVar[dict[str, Any]] = {}
     _default_classes: ClassVar[list[str]] = []
     _default_style: ClassVar[dict[str, str]] = {}
-    MARKDOWN_SKIP: bool = False
-    '''Set to True on non-visual elements (timers, keyboard handlers, etc.) to exclude from markdown output.'''
 
     def __init__(self, tag: str | None = None, *, _client: Client | None = None) -> None:
         """Generic Element
@@ -219,33 +217,17 @@ class Element(Visibility):
 
         Subclasses should override ``_render_markdown`` instead of this method.
         """
-        if not self.visible or self.MARKDOWN_SKIP:
+        if not self.visible:
             return ''
-        return self._render_markdown()
+        result = self._render_markdown()
+        return result if result is not None else ''
 
-    def _render_markdown(self) -> str:
-        """Return the markdown body for this element.
+    def _render_markdown(self) -> str | None:
+        """Return the markdown body for this element, or None to skip.
 
         Override in subclasses to customise the markdown output.
-        The visibility / MARKDOWN_SKIP guard is already handled by ``_to_markdown``.
+        The visibility guard is already handled by ``_to_markdown``.
         """
-        # Content elements (Markdown, Html, Mermaid)
-        if hasattr(self, 'content') and isinstance(self.content, str):  # pylint: disable=no-member
-            return self.content or ''  # pylint: disable=no-member
-        # Text elements (Label, Badge, Chip)
-        if self._text is not None:
-            return self._text
-        # Label+Value form elements (Input, Select, Number, Textarea, ...)
-        # Only match when the value is a simple displayable type to avoid misleading output
-        # from layout/value elements like Drawer, Carousel, etc. (whose value is not text).
-        if hasattr(self, 'label') and hasattr(self, 'value'):
-            value = self.value  # pylint: disable=no-member
-            if isinstance(value, (str, int, float)) or (isinstance(value, list) and all(isinstance(v, (str, int, float)) for v in value)):
-                label = self.label or ''  # pylint: disable=no-member
-                if isinstance(value, list):
-                    value = ', '.join(str(v) for v in value)
-                return f'{label}: {value}' if label else str(value if value != '' else '')
-        # Recurse into children
         return self._children_to_markdown()
 
     def _children_to_markdown(self) -> str:

--- a/nicegui/elements/altair.py
+++ b/nicegui/elements/altair.py
@@ -31,3 +31,6 @@ class Altair(AnyWidget):
             chart = altair.JupyterChart(chart)
 
         super().__init__(chart, throttle=throttle)  # type: ignore[arg-type]
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/audio.py
+++ b/nicegui/elements/audio.py
@@ -50,3 +50,6 @@ class Audio(SourceElement, component='audio.js'):
     def pause(self) -> None:
         """Pause audio."""
         self.run_method('pause')
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/avatar.py
+++ b/nicegui/elements/avatar.py
@@ -35,3 +35,6 @@ class Avatar(IconElement, BackgroundColorElement, TextColorElement):
         self._props['rounded'] = rounded
         self._props.set_optional('size', size)
         self._props.set_optional('font-size', font_size)
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/badge.py
+++ b/nicegui/elements/badge.py
@@ -24,3 +24,6 @@ class Badge(TextElement, BackgroundColorElement, TextColorElement):
         """
         super().__init__(tag='q-badge', text=text, text_color=text_color, background_color=color)
         self._props['outline'] = outline
+
+    def _render_markdown(self) -> str | None:
+        return self._text or ''

--- a/nicegui/elements/chip.py
+++ b/nicegui/elements/chip.py
@@ -57,3 +57,6 @@ class Chip(IconElement, ValueElement[bool], TextElement, BackgroundColorElement,
         self._props['clickable'] = True
         self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self
+
+    def _render_markdown(self) -> str | None:
+        return self._text or ''

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -75,3 +75,7 @@ class ColorInput(LabelElement, ValueElement[str | None], DisableableElement):
         luminance = rgb_to_yiq(r, g, b)[0]
         icon_color = 'grey-10' if luminance > 0.5 else 'grey-3'
         self.button.style(f'background-color: {color}').props(f'color="{icon_color}"')
+
+    def _render_markdown(self) -> str | None:
+        label = self.label or 'Color'
+        return f'{label}: {self.value}' if self.value else ''

--- a/nicegui/elements/color_picker.py
+++ b/nicegui/elements/color_picker.py
@@ -40,3 +40,6 @@ class ColorPicker(Menu):
         """Add a callback to be invoked when a color is picked."""
         self._pick_handlers.append(callback)
         return self
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/colors.py
+++ b/nicegui/elements/colors.py
@@ -4,7 +4,6 @@ from .mixins.color_elements import QUASAR_COLORS
 
 
 class Colors(Element, component='colors.js'):
-    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self, *,
@@ -50,3 +49,6 @@ class Colors(Element, component='colors.js'):
 
         self._props.add_rename('dark_page', 'dark-page')  # DEPRECATED: remove in NiceGUI 4.0
         self._props.add_rename('custom_colors', 'custom-colors')  # DEPRECATED: remove in NiceGUI 4.0
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/context_menu.py
+++ b/nicegui/elements/context_menu.py
@@ -2,7 +2,6 @@ from ..element import Element
 
 
 class ContextMenu(Element):
-    MARKDOWN_SKIP = True
 
     def __init__(self) -> None:
         """Context Menu
@@ -22,3 +21,6 @@ class ContextMenu(Element):
     def close(self) -> None:
         """Close the context menu."""
         self.run_method('hide')
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/dark_mode.py
+++ b/nicegui/elements/dark_mode.py
@@ -4,7 +4,6 @@ from .mixins.value_element import ValueElement
 
 
 class DarkMode(ValueElement[bool | None], component='dark_mode.js'):
-    MARKDOWN_SKIP = True
     VALUE_PROP = 'value'
 
     @resolve_defaults
@@ -47,3 +46,6 @@ class DarkMode(ValueElement[bool | None], component='dark_mode.js'):
         This will use the client's system preference.
         """
         self.value = None
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/date.py
+++ b/nicegui/elements/date.py
@@ -33,3 +33,6 @@ class Date(ValueElement[Any], DisableableElement):
         """
         super().__init__(tag='q-date', value=value, on_value_change=on_change)
         self._props['mask'] = mask
+
+    def _render_markdown(self) -> str | None:
+        return f'Date: {self.value}' if self.value else ''

--- a/nicegui/elements/date_input.py
+++ b/nicegui/elements/date_input.py
@@ -57,3 +57,7 @@ class DateInput(LabelElement, ValueElement[str | None], DisableableElement):
             return {'from': from_date, 'to': to_date}
         else:
             return value
+
+    def _render_markdown(self) -> str | None:
+        label = self.label or 'Date'
+        return f'{label}: {self.value}' if self.value else ''

--- a/nicegui/elements/editor.py
+++ b/nicegui/elements/editor.py
@@ -32,3 +32,6 @@ class Editor(ValueElement[str], DisableableElement, component='editor.js', defau
         super()._handle_value_change(value)
         if self._send_update_on_value_change:
             self.run_method('updateValue')
+
+    def _render_markdown(self) -> str | None:
+        return self.value or ''

--- a/nicegui/elements/fab.py
+++ b/nicegui/elements/fab.py
@@ -82,3 +82,6 @@ class FabAction(LabelElement, IconElement, BackgroundColorElement, DisableableEl
         """Add a callback to be invoked when the action element is clicked."""
         self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self
+
+    def _render_markdown(self) -> str | None:
+        return self.label or ''

--- a/nicegui/elements/fullscreen.py
+++ b/nicegui/elements/fullscreen.py
@@ -6,7 +6,6 @@ from .mixins.value_element import ValueElement
 
 
 class Fullscreen(ValueElement[bool], component='fullscreen.js'):
-    MARKDOWN_SKIP = True
     LOOPBACK = None
 
     @resolve_defaults
@@ -61,3 +60,6 @@ class Fullscreen(ValueElement[bool], component='fullscreen.js'):
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)
         self.run_method('enter' if value else 'exit')
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/html.py
+++ b/nicegui/elements/html.py
@@ -29,3 +29,6 @@ class Html(ContentElement, component='html.js'):
         if callable(self._sanitize):
             content = self._sanitize(content)
         super()._handle_content_change(content)
+
+    def _render_markdown(self) -> str | None:
+        return self.content or ''

--- a/nicegui/elements/icon.py
+++ b/nicegui/elements/icon.py
@@ -4,7 +4,6 @@ from .mixins.name_element import NameElement
 
 
 class Icon(NameElement, TextColorElement):
-    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self,
@@ -26,3 +25,6 @@ class Icon(NameElement, TextColorElement):
         super().__init__(tag='q-icon', name=name, text_color=color)
 
         self._props.set_optional('size', size)
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -114,3 +114,8 @@ class Input(LabelElement, ValidationElement[str | None], DisableableElement, com
         super()._handle_value_change(value)
         if self._send_update_on_value_change:
             self.run_method('updateValue')
+
+    def _render_markdown(self) -> str | None:
+        label = self.label or ''
+        v = self.value or ''
+        return f'{label}: {v}' if label else str(v)

--- a/nicegui/elements/input_chips.py
+++ b/nicegui/elements/input_chips.py
@@ -57,3 +57,10 @@ class InputChips(LabelElement, ValidationElement[list[str]], DisableableElement)
 
     def _event_args_to_value(self, e: GenericEventArguments) -> list[str]:
         return e.args or []
+
+    def _render_markdown(self) -> str | None:
+        if not self.value:
+            return ''
+        label = self.label or ''
+        chips = ', '.join(str(v) for v in self.value)
+        return f'{label}: {chips}' if label else chips

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -134,6 +134,10 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
             content = self._sanitize(content)
         return super()._handle_content_change(content)
 
+    def _render_markdown(self) -> str | None:
+        src = self._props.get('src', '')
+        return f'![image]({src})' if src else ''
+
 
 class InteractiveImageLayer(SourceElement, ContentElement, component='interactive_image.js'):
     CONTENT_PROP = 'content'

--- a/nicegui/elements/item.py
+++ b/nicegui/elements/item.py
@@ -48,6 +48,9 @@ class ItemSection(TextElement):
         """
         super().__init__(tag='q-item-section', text=text)
 
+    def _render_markdown(self) -> str | None:
+        return self._text or ''
+
 
 class ItemLabel(TextElement):
 
@@ -59,3 +62,6 @@ class ItemLabel(TextElement):
         :param text: text to be displayed (default: "")
         """
         super().__init__(tag='q-item-label', text=text)
+
+    def _render_markdown(self) -> str | None:
+        return self._text or ''

--- a/nicegui/elements/keyboard.py
+++ b/nicegui/elements/keyboard.py
@@ -17,7 +17,6 @@ from ..events import (
 
 
 class Keyboard(Element, component='keyboard.js'):
-    MARKDOWN_SKIP = True
     active = BindableProperty()
 
     @resolve_defaults
@@ -106,3 +105,6 @@ class Keyboard(Element, component='keyboard.js'):
         """Add a callback to be invoked when keyboard events occur."""
         self._key_handlers.append(handler)
         return self
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/knob.py
+++ b/nicegui/elements/knob.py
@@ -7,7 +7,6 @@ from .mixins.value_element import ValueElement
 
 
 class Knob(ValueElement[float], DisableableElement, TextColorElement):
-    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self,
@@ -53,3 +52,6 @@ class Knob(ValueElement[float], DisableableElement, TextColorElement):
         if show_value:
             with self:
                 self.label = Label().bind_text_from(self, 'value')
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/label.py
+++ b/nicegui/elements/label.py
@@ -11,3 +11,6 @@ class Label(TextElement):
         :param text: the content of the label
         """
         super().__init__(tag='div', text=text)
+
+    def _render_markdown(self) -> str | None:
+        return self._text or ''

--- a/nicegui/elements/line_plot.py
+++ b/nicegui/elements/line_plot.py
@@ -102,3 +102,6 @@ class LinePlot(Pyplot):
             line.set_data([], [])
         self._convert_to_html()
         return self
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -59,6 +59,9 @@ class Markdown(ContentElement, component='markdown.js', default_classes='nicegui
             HtmlFormatter(nobackground=True, style='github-dark').get_style_defs('.body--dark .codehilite')
         )
 
+    def _render_markdown(self) -> str | None:
+        return self.content or ''
+
     def _handle_content_change(self, content: str) -> None:
         html = prepare_content(content, extras=' '.join(self.extras))
         if callable(self._sanitize):

--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -158,3 +158,8 @@ class Number(LabelElement, ValidationElement[float | None], DisableableElement):
         if value == '':
             return 0
         return self.format % float(value)
+
+    def _render_markdown(self) -> str | None:
+        label = self.label or ''
+        v = self.value
+        return f'{label}: {v}' if label else str(v) if v is not None else ''

--- a/nicegui/elements/page_scroller.py
+++ b/nicegui/elements/page_scroller.py
@@ -43,3 +43,6 @@ class PageScroller(Element):
         self._props['duration'] = duration * 1000
         self._props.set_bool('expand', expand)
         self._props.set_bool('reverse', reverse)
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/pagination.py
+++ b/nicegui/elements/pagination.py
@@ -5,7 +5,6 @@ from .mixins.value_element import ValueElement
 
 
 class Pagination(ValueElement[int | None], DisableableElement):
-    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self,
@@ -56,3 +55,6 @@ class Pagination(ValueElement[int | None], DisableableElement):
     @direction_links.setter
     def direction_links(self, value: bool) -> None:
         self._props['direction-links'] = value
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/parallax.py
+++ b/nicegui/elements/parallax.py
@@ -27,3 +27,6 @@ class Parallax(Image, component='image.js'):
         self._props['height'] = height
         self._props['speed'] = speed
         self._props['tag'] = 'q-parallax'
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/progress.py
+++ b/nicegui/elements/progress.py
@@ -5,7 +5,6 @@ from .mixins.value_element import ValueElement
 
 
 class LinearProgress(ValueElement[float], TextColorElement):
-    MARKDOWN_SKIP = True
     VALUE_PROP = 'value'
 
     @resolve_defaults
@@ -32,9 +31,11 @@ class LinearProgress(ValueElement[float], TextColorElement):
             with self:
                 label().classes('absolute-center text-white').style('font-size: 0.875rem').bind_text_from(self, 'value')
 
+    def _render_markdown(self) -> str | None:
+        return None
+
 
 class CircularProgress(ValueElement[float], TextColorElement):
-    MARKDOWN_SKIP = True
     VALUE_PROP = 'value'
 
     @resolve_defaults
@@ -68,3 +69,6 @@ class CircularProgress(ValueElement[float], TextColorElement):
         if show_value:
             with self:
                 label().classes('absolute-center').style('font-size: 0.75rem').bind_text_from(self, 'value')
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/pyplot.py
+++ b/nicegui/elements/pyplot.py
@@ -75,6 +75,9 @@ class Pyplot(Element, default_classes='nicegui-pyplot'):
         plt.close(self.fig)
         super()._handle_delete()
 
+    def _render_markdown(self) -> str | None:
+        return None
+
 
 class Matplotlib(Element, default_classes='nicegui-matplotlib'):
 

--- a/nicegui/elements/query.py
+++ b/nicegui/elements/query.py
@@ -10,7 +10,6 @@ from ..style import Style
 
 
 class QueryElement(Element, component='query.js'):
-    MARKDOWN_SKIP = True
 
     def __init__(self, selector: str) -> None:
         super().__init__()
@@ -118,3 +117,6 @@ class Query:
         if element.props['props']:
             element.run_method('add_props', element.props['props'])
         return self
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/range.py
+++ b/nicegui/elements/range.py
@@ -62,3 +62,6 @@ class Range(ValueElement[dict[str, float] | None], DisableableElement):
         if self._props['step'] == value:
             return
         self._props['step'] = value
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/rating.py
+++ b/nicegui/elements/rating.py
@@ -5,7 +5,6 @@ from .mixins.value_element import ValueElement
 
 
 class Rating(ValueElement[float | None], DisableableElement):
-    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self,
@@ -41,3 +40,6 @@ class Rating(ValueElement[float | None], DisableableElement):
         self._props.set_optional('icon-selected', icon_selected)
         self._props.set_optional('icon-half', icon_half)
         self._props.set_optional('size', size)
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/restructured_text.py
+++ b/nicegui/elements/restructured_text.py
@@ -17,6 +17,9 @@ class ReStructuredText(Markdown):
         """
         super().__init__(content=content)
 
+    def _render_markdown(self) -> str | None:
+        return self.content or ''
+
     def _handle_content_change(self, content: str) -> None:
         html = prepare_content(content)
         if self._props.get('innerHTML') != html:

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -176,3 +176,10 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
                     self.options.update({key: value})
             self._update_values_and_labels()
             return key
+
+    def _render_markdown(self) -> str | None:
+        label = self.label or ''
+        v = self.value
+        if isinstance(v, list):
+            v = ', '.join(str(x) for x in v)
+        return f'{label}: {v}' if label else str(v) if v is not None else ''

--- a/nicegui/elements/skeleton.py
+++ b/nicegui/elements/skeleton.py
@@ -68,3 +68,6 @@ class Skeleton(Element):
         self._props.set_optional('size', size)
         self._props.set_optional('width', width)
         self._props.set_optional('height', height)
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/slider.py
+++ b/nicegui/elements/slider.py
@@ -5,7 +5,6 @@ from .mixins.value_element import ValueElement
 
 
 class Slider(ValueElement[float | None], DisableableElement):
-    MARKDOWN_SKIP = True
 
     @resolve_defaults
     def __init__(self, *,
@@ -29,3 +28,6 @@ class Slider(ValueElement[float | None], DisableableElement):
         self._props['min'] = min
         self._props['max'] = max
         self._props['step'] = step
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/space.py
+++ b/nicegui/elements/space.py
@@ -11,3 +11,6 @@ class Space(Element):
         Its purpose is to simply fill all available space inside of a flexbox element.
         """
         super().__init__('q-space')
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/spinner.py
+++ b/nicegui/elements/spinner.py
@@ -51,3 +51,6 @@ class Spinner(TextColorElement):
         super().__init__(tag='q-spinner' if type == 'default' else f'q-spinner-{type}', text_color=color)
         self._props['size'] = size
         self._props['thickness'] = thickness
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/tabs.py
+++ b/nicegui/elements/tabs.py
@@ -33,6 +33,9 @@ class Tab(LabelElement, IconElement, DisableableElement):
             helpers.warn_once('A ui.tab should be a child of a ui.tabs element. '
                               'This will raise an error in NiceGUI 4.0.')
 
+    def _render_markdown(self) -> str | None:
+        return self.label or ''
+
 
 class TabPanel(DisableableElement, default_classes='nicegui-tab-panel'):
 

--- a/nicegui/elements/time.py
+++ b/nicegui/elements/time.py
@@ -23,3 +23,6 @@ class Time(ValueElement[str | None], DisableableElement):
         """
         super().__init__(tag='q-time', value=value, on_value_change=on_change)
         self._props['mask'] = mask
+
+    def _render_markdown(self) -> str | None:
+        return f'Time: {self.value}' if self.value else ''

--- a/nicegui/elements/time_input.py
+++ b/nicegui/elements/time_input.py
@@ -39,3 +39,7 @@ class TimeInput(LabelElement, ValueElement[str | None], DisableableElement):
                     self.picker = time()
 
         self.picker.bind_value(self)
+
+    def _render_markdown(self) -> str | None:
+        label = self.label or 'Time'
+        return f'{label}: {self.value}' if self.value else ''

--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -7,7 +7,6 @@ from ..timer import Timer as BaseTimer
 
 
 class Timer(BaseTimer, Element, component='timer.js'):
-    MARKDOWN_SKIP = True
 
     def _get_context(self) -> AbstractContextManager:
         return self.parent_slot or nullcontext()
@@ -46,3 +45,6 @@ class Timer(BaseTimer, Element, component='timer.js'):
 
     def set_visibility(self, visible: bool) -> None:
         raise NotImplementedError('Use `activate()`, `deactivate()` or `cancel()`. See #3670 for more information.')
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/tooltip.py
+++ b/nicegui/elements/tooltip.py
@@ -2,7 +2,6 @@ from .mixins.text_element import TextElement
 
 
 class Tooltip(TextElement):
-    MARKDOWN_SKIP = True
 
     def __init__(self, text: str = '') -> None:
         """Tooltip
@@ -15,3 +14,6 @@ class Tooltip(TextElement):
         :param text: the content of the tooltip (default: '')
         """
         super().__init__(tag='q-tooltip', text=text)
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -180,3 +180,6 @@ class Tree(FilterElement):
         if node_keys is not None:
             return set(node_keys)
         return {node[self._props['node-key']] for node in self.nodes()}
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -123,3 +123,6 @@ class Upload(LabelElement, DisableableElement, component='upload.js'):
     def _handle_delete(self) -> None:
         app.remove_route(self._props['url'])
         super()._handle_delete()
+
+    def _render_markdown(self) -> str | None:
+        return None

--- a/nicegui/elements/video.py
+++ b/nicegui/elements/video.py
@@ -50,3 +50,6 @@ class Video(SourceElement, component='video.js'):
     def pause(self) -> None:
         """Pause video."""
         self.run_method('pause')
+
+    def _render_markdown(self) -> str | None:
+        return None


### PR DESCRIPTION
## Summary

- Replaces duck-typing dispatch (`hasattr` checks for `content`, `_text`, `label`/`value`) in `Element._render_markdown` with explicit per-class overrides
- Removes `MARKDOWN_SKIP` class attribute — non-visual elements now return `None` from `_render_markdown` instead
- Default `_render_markdown` recurses into children via `_children_to_markdown()`, matching prior behavior for generic container elements
- ~45 element classes gain explicit `_render_markdown` methods (text, form, media, layout)
- All 43 markdown tests pass, pre-commit clean

## Test plan
- [x] `pytest tests/test_markdown_response.py tests/test_markdown.py` — 43/43 pass
- [x] `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)