### PR TITLE
Markdown Phase 2: emit `#`/`##` heading prefixes for documentation pages

### DIFF
--- a/tests/test_markdown_response.py
+++ b/tests/test_markdown_response.py
@@ -220,6 +220,25 @@ async def test_notification(user: User):
     await _assert_markdown(user, build, 'Page content\n\nHello notification!')
 
 
+async def test_subclass_can_override_render_markdown(user: User):
+    class _H2Label(ui.label):
+        def _render_markdown(self) -> str:
+            return f'## {self._text or ""}'
+
+    class _H2Link(ui.link):
+        def _render_markdown(self) -> str:
+            return f'## [{self._text or ""}]({self._props["href"]})'
+
+    class _H1Markdown(ui.markdown):
+        def _render_markdown(self) -> str:
+            return f'# {self.content}'
+
+    await _assert_markdown(user, lambda: _H2Label('Section'), '## Section')
+    await _assert_markdown(user, lambda: _H2Link('Label', '/documentation/label'),
+                           '## [Label](/documentation/label)')
+    await _assert_markdown(user, lambda: _H1Markdown('*Text* Elements'), '# *Text* Elements')
+
+
 async def _assert_markdown(user: User, build: Callable, expected: str) -> None:
     @ui.page('/', markdown=True)
     def _():

--- a/website/design.py
+++ b/website/design.py
@@ -89,10 +89,31 @@ MERMAID_CLASSES = f'''
 
 # --- Helpers ---
 
+class _MarkdownH1(ui.markdown):
+    """``ui.markdown`` that emits a leading ``# `` in the markdown response."""
+
+    def _render_markdown(self) -> str:
+        return f'# {super()._render_markdown()}'
+
+
+class _MarkdownH2Link(ui.link):
+    """``ui.link`` that emits a leading ``## `` in the markdown response."""
+
+    def _render_markdown(self) -> str:
+        return f'## {super()._render_markdown()}'
+
+
+class _MarkdownH2Label(ui.label):
+    """``ui.label`` that emits a leading ``## `` in the markdown response."""
+
+    def _render_markdown(self) -> str:
+        return f'## {super()._render_markdown()}'
+
+
 def section_heading(subtitle_: str, title_: str) -> None:
     """Render a section heading with a subtitle."""
     ui.label(subtitle_).classes(f'{TEXT_19PX} font-medium {TEXT_SECONDARY}')
-    ui.markdown(title_).classes(f'{TEXT_SECTION_TITLE} font-medium mt-[-12px] [&_em]:not-italic [&_em]:{TEXT_BLUE}')
+    _MarkdownH1(title_).classes(f'{TEXT_SECTION_TITLE} font-medium mt-[-12px] [&_em]:not-italic [&_em]:{TEXT_BLUE}')
 
 
 def subheading(text: str, *, link: str | None = None, major: bool = False, anchor_name: str | None = None) -> None:
@@ -102,9 +123,9 @@ def subheading(text: str, *, link: str | None = None, major: bool = False, ancho
     with ui.row().classes('group gap-2 items-center relative'):
         classes = TEXT_32PX if major else TEXT_24PX
         if link:
-            ui.link(text, link).classes(classes)
+            _MarkdownH2Link(text, link).classes(classes)
         else:
-            ui.label(text).classes(classes)
+            _MarkdownH2Label(text).classes(classes)
         with ui.link(target=f'#{name}').classes('absolute').style('transform: translateX(-150%)'):
             phosphor_icon('ph-link').classes('opacity-0 group-hover:opacity-50 transition-opacity')
 


### PR DESCRIPTION
## Motivation

Phase 2 polish for #5889 (markdown content negotiation, merged 2026-04-24). Per discussion zauberzeug/nicegui#6007 finding 1, agents reading nicegui.io via `Accept: text/markdown` get no heading-level cues for in-page section structure on documentation pages.

The page-title H1 (`# Text Elements | NiceGUI`) is correctly emitted at the top, but:
- The in-page H1 (`section_heading` title) renders as literal `*Text* Elements` with no `#` prefix.
- Per-element subheadings ("Label", "Link", "Chat Message", etc.) render as plain links `[Label](/documentation/label)` with no `##`.

That makes structural navigation impossible — agents see one continuous stream of code blocks and prose with no cues about which section they're in.

## Implementation

Three private subclasses in `website/design.py`:
- `_MarkdownH1(ui.markdown)` — emits `# {content}` in the markdown stream
- `_MarkdownH2Link(ui.link)` — emits `## [{text}]({href})`
- `_MarkdownH2Label(ui.label)` — emits `## {text}`

`section_heading()` and `subheading()` use these instead of plain `ui.markdown` / `ui.link` / `ui.label`. **HTML rendering is unchanged** — the subclasses inherit all visual behavior; they only override `_render_markdown()`.

One small test in `tests/test_markdown_response.py` proves the subclass-override pattern works for `ui.label` / `ui.link` / `ui.markdown` subclasses.

## Phase 2 cross-references

This is **PR 1 of 5** (+ a possible PR 6 for the UA-based safety net described in zauberzeug/nicegui#6007's follow-up comment):

| # | Branch | Finding | Maturity |
|---|---|---|---|
| 1 | `mdp2-headings` (this PR) | 1 (heading hierarchy) | PROD-READY |
| 2 | `mdp2-demo-preview` | 2 (demo panel placeholder) | PROD-READY |
| 3 | `mdp2-decorative-html` | 3 (phosphor / anchor div / empty link) | PROD-READY |
| 4 | `mdp2-button-noise` | 4 (`[Button]` volume) | PROD-READY |
| 5 | `mdp2-rest-polish` | 5 (ReST docstring leak) | EXPLORATORY |

**Conflict note:** PR 3 (`mdp2-decorative-html`) also edits `subheading()` in `website/design.py` — for the anchor `<div id=...>` and the icon-only anchor link, both of which my changes leave untouched. Trivial to resolve; the changes commute semantically.

## E2E results

Captured against the local NiceGUI website running `main.py` on port 8801 with `markdown=True`:

`/documentation/section_text_elements` (baseline 428 lines):
- `^# ` markers: **1 → 2** (page title + in-page H1 `# *Text* Elements`)
- `^## ` markers: **0 → 9** (Label, Link, Chat Message, Generic Element, Markdown Element, ReStructuredText, Mermaid Diagrams, HTML Element, Other HTML Elements)
- 20 diff lines vs baseline, all expected heading-prefix additions

`/documentation/label`: `^# ` 1 → 2; `^## ` 0 → 7; 16 diff lines.

## Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will…"
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the security advisory process.
- [x] Pytests have been added.
- [x] Documentation is not necessary for an underlying agent-facing change.
