### PR TITLE
Markdown Phase 2: skip browser-window placeholder in markdown stream

### DIFF
--- a/tests/test_markdown_response.py
+++ b/tests/test_markdown_response.py
@@ -126,6 +126,22 @@ async def test_nested_containers(user: User):
     await _assert_markdown(user, build, 'First\n\nSecond')
 
 
+async def test_instance_level_render_markdown_override(user: User):
+    """An element can opt out of markdown rendering by overriding `_render_markdown` on the instance.
+
+    This is the mechanism used by `website/documentation/windows.py:browser_window` to skip
+    the demo preview placeholder (localhost:8080 / loading.gif) in markdown output.
+    """
+    def build():
+        ui.label('Visible')
+        with ui.column() as skipped:
+            ui.label('Hidden by override')
+            ui.image('/static/loading.gif')
+        skipped._render_markdown = lambda: ''  # type: ignore[method-assign]
+        ui.label('Also visible')
+    await _assert_markdown(user, build, 'Visible\n\nAlso visible')
+
+
 async def test_no_accept_returns_html(user: User):
     @ui.page('/')
     def page():

--- a/website/documentation/windows.py
+++ b/website/documentation/windows.py
@@ -70,6 +70,11 @@ def browser_window(content: Callable, *, tab: str | Callable | None = None, lazy
                 if callable(result):
                     inner_result = result()
                     assert not helpers.should_await(inner_result), 'async functions are not supported in non-lazy demos'
+    # The browser-window chrome (tab label, spinner) is irrelevant to agents reading via
+    # `Accept: text/markdown`, and the lazy preview never hydrates server-side anyway, so the
+    # placeholder leaks `localhost:8080` and `![](/static/loading.gif)` into the markdown stream.
+    # Skip rendering the entire window in markdown output; the python_window source remains.
+    window._render_markdown = lambda: ''  # type: ignore[method-assign]  # pylint: disable=protected-access
     return window
 
 


### PR DESCRIPTION
## Motivation

Phase 2 polish for #5889 (markdown content negotiation, merged 2026-04-24). Per discussion zauberzeug/nicegui#6007 finding 2: every documentation section has a `browser_window` preview pane that, in the markdown stream, appears as:

```
localhost:8080

![](/static/loading.gif)
```

…because the demo loads via WebSocket-driven intersection observer, which never fires for a markdown response. Net effect: the "what does this look like rendered" half of every example is gone — only the source code from `python_window` survives, surrounded by useless localhost / loading-gif noise.

## Implementation

In `website/documentation/windows.py:browser_window()`, attach an empty `_render_markdown` to the column instance returned, so the entire browser-window placeholder (header `localhost:8080`, ph-globe icon, loading spinner image) contributes nothing to the markdown stream. Source code rendered by `python_window` is unaffected.

This is **Tier A — skip**: the simplest fix that meaningfully helps agents. **Tier B — eager-render** (synchronously invoking the demo function during markdown rendering and recursing into the rendered tree) was considered but rejected for now: many demos are wrapped in `@intersection_observer`, are async, or call into stateful clients — partial coverage would mislead agents. Tier B remains future work.

One new test (`test_instance_level_render_markdown_override`) documents the contract that lets `browser_window` opt out without subclassing.

## Phase 2 cross-references

PR 2 of 5 (see #6007 follow-up). See `mdp2-headings` for the full lineup. No conflicts with PRs 1, 3, 4, 5.

## E2E results

`/documentation/section_text_elements` (baseline 428 lines, post-fix 374):
- `localhost:8080` count: **9 → 0** ✓
- `loading.gif` count: **9 → 1** (residual lives in the global page header layout, not in any `browser_window`; out of scope for this PR)

## Known gaps

- Demos that don't use `browser_window` (rare) are unaffected — they already render fine via their own elements.
- Tier B (eager-render demos) would actually populate the preview area with the demo's emitted markdown. Worth pursuing but needs careful triage of sync vs async demos and intersection_observer side-effects.

## Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will…"
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the security advisory process.
- [x] Pytests have been added.
- [x] Documentation is not necessary for an underlying agent-facing change.
