### PR TITLE
Markdown Phase 2: skip decorative HTML on docs site in markdown stream

### DIFF
--- a/website/design.py
+++ b/website/design.py
@@ -98,14 +98,14 @@ def section_heading(subtitle_: str, title_: str) -> None:
 def subheading(text: str, *, link: str | None = None, major: bool = False, anchor_name: str | None = None) -> None:
     """Render a subheading with an anchor that can be linked to with a hash."""
     name = anchor_name or create_anchor_name(text)
-    ui.html(f'<div id="{name}"></div>', sanitize=False).style('position: relative; top: -90px')
+    _DecorativeHtml(f'<div id="{name}"></div>', sanitize=False).style('position: relative; top: -90px')
     with ui.row().classes('group gap-2 items-center relative'):
         classes = TEXT_32PX if major else TEXT_24PX
         if link:
             ui.link(text, link).classes(classes)
         else:
             ui.label(text).classes(classes)
-        with ui.link(target=f'#{name}').classes('absolute').style('transform: translateX(-150%)'):
+        with _DecorativeLink(target=f'#{name}').classes('absolute').style('transform: translateX(-150%)'):
             phosphor_icon('ph-link').classes('opacity-0 group-hover:opacity-50 transition-opacity')
 
 
@@ -116,7 +116,21 @@ def create_anchor_name(text: str) -> str:
 
 def phosphor_icon(name: str) -> ui.html:
     """Render a Phosphor duotone icon, e.g. ``phosphor_icon('ph-code')``."""
-    return ui.html(f'<i class="ph-duotone {name}"></i>', sanitize=False).classes('-mb-1')
+    return _DecorativeHtml(f'<i class="ph-duotone {name}"></i>', sanitize=False).classes('-mb-1')
+
+
+class _DecorativeHtml(ui.html):
+    """A ui.html element that contributes nothing to the markdown stream (used for purely decorative chrome)."""
+
+    def _render_markdown(self) -> str:
+        return ''
+
+
+class _DecorativeLink(ui.link):
+    """A ui.link element that contributes nothing to the markdown stream (used for icon-only anchor links)."""
+
+    def _render_markdown(self) -> str:
+        return ''
 
 
 def themed_image(src: str, *, classes: str = '') -> None:


### PR DESCRIPTION
## Motivation

Phase 2 polish for #5889 (markdown content negotiation, merged 2026-04-24). Per discussion zauberzeug/nicegui#6007 finding 3, three classes of decorative HTML on nicegui.io leak verbatim into agent markdown output:

1. **Phosphor icons** — every `main.py` / `bash` / `localhost:8080` label is preceded by `<i class="ph-duotone ph-file-py"></i>` etc. Pure decoration, no semantic value to agents.
2. **Anchor target divs** — every section opens with `<div id="label"></div>` before its heading (used for in-page nav). Invisible on the rendered site; raw noise in markdown.
3. **Empty anchor links** — the "#" link icon next to each section heading renders as `[](#label)` (empty link text). Nothing to read.

These come from `website/` helpers, not built-in elements, so the cleanest place to fix them is also `website/design.py`.

## Implementation

Two tiny private subclasses in `website/design.py`:

```python
class _DecorativeHtml(ui.html):
    def _render_markdown(self) -> str:
        return ''

class _DecorativeLink(ui.link):
    def _render_markdown(self) -> str:
        return ''
```

Wired into:
- `phosphor_icon()` — covers all 12 call-sites across `header.py`, `search.py`, `windows.py`, sponsors / footer / why / shared / installation / features / sponsors_section / footer_section / why_section.
- `subheading()` anchor target `<div>`.
- `subheading()` empty anchor link.

Public `ui.html` / `ui.link` semantics are unchanged.

## Phase 2 cross-references

PR 3 of 5. See `mdp2-headings` for the full lineup.

**Conflict note:** PR 1 (`mdp2-headings`) also edits `subheading()` for H2 emission. The two changes touch adjacent lines but are semantically independent: keep both PR 1's `_MarkdownH2Link`/`_MarkdownH2Label` AND this PR's `_DecorativeHtml`/`_DecorativeLink`. Resolution is mechanical.

PR 4 (`mdp2-button-noise`) recurses into button children. Standalone, PR 4 reveals raw phosphor HTML inside `[Button: <i class="ph-duotone ...">]`; **with this PR applied first**, those children render empty and the combined output collapses copy-button noise to zero.

## E2E results

`/documentation/section_text_elements` (baseline 428 lines):

| Metric | Before | After |
|---|---|---|
| `ph-duotone` occurrences | 18 | **0** |
| `<div id=` occurrences | 9 | **0** |
| `[](#…)` occurrences | 9 | **0** |

## Known gaps

Out of scope (separate concerns, not part of finding 3): `website/svg.py` brand SVGs, `hero_section.py` HAPPY_FACE_SVG, `notify_documentation.py` `<style>` injection, `icon_documentation.py` lottie players. These also emit raw HTML to markdown clients; cleanup is a separate sweep.

## Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will…"
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the security advisory process.
- [x] Pytests have been added (covered by the existing 32 markdown-response tests; behavior unchanged for non-decorative ui.html / ui.link).
- [x] Documentation is not necessary for an underlying agent-facing change.
