### PR TITLE
Markdown Phase 2: drop empty `[Button]`, prefer aria-label / child content

### DIFF
--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -46,9 +46,13 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
     def _render_markdown(self) -> str:
         if label := self._props.get('label'):
             return f'[Button: {label}]'
+        if aria_label := self._props.get('aria-label'):
+            return f'[Button: {aria_label}]'
         if icon := self._props.get('icon'):
             return f'[Button: icon:{icon}]'
-        return '[Button]'
+        if children := self._children_to_markdown().strip():
+            return f'[Button: {children}]'
+        return ''
 
     def _text_to_model_text(self, text: str) -> None:
         self._props['label'] = text

--- a/tests/test_markdown_response.py
+++ b/tests/test_markdown_response.py
@@ -98,7 +98,16 @@ async def test_button(user: User):
     await _assert_markdown(user, lambda: ui.button('Click me'), '[Button: Click me]')
     await _assert_markdown(user, lambda: ui.button('Click me', icon='thumb_up'), '[Button: Click me]')
     await _assert_markdown(user, lambda: ui.button(icon='face'), '[Button: icon:face]')
-    await _assert_markdown(user, ui.button, '[Button]')
+    await _assert_markdown(user, ui.button, '')
+
+    def aria_button():
+        ui.button().props('aria-label="Save"')
+    await _assert_markdown(user, aria_button, '[Button: Save]')
+
+    def child_button():
+        with ui.button():
+            ui.label('Custom content')
+    await _assert_markdown(user, child_button, '[Button: Custom content]')
 
 
 async def test_code_element(user: User):


### PR DESCRIPTION
## Motivation

Phase 2 polish for #5889 (markdown content negotiation, merged 2026-04-24). Per discussion zauberzeug/nicegui#6007 finding 4: on code-snippet-heavy doc pages, `[Button]` is the single most-repeated token in the markdown stream (≥9 occurrences per page from copy buttons whose only content is a phosphor `ph-copy` child element).

The current `Button._render_markdown` only checks `label` and `icon` props. Buttons whose visible icon comes from a child element fall through to the bare `[Button]` placeholder, which is pure noise.

## Implementation

`nicegui/elements/button.py:_render_markdown()` is extended to consider, in order:

```python
def _render_markdown(self) -> str:
    if label := self._props.get('label'):
        return f'[Button: {label}]'
    if aria_label := self._props.get('aria-label'):
        return f'[Button: {aria_label}]'
    if icon := self._props.get('icon'):
        return f'[Button: icon:{icon}]'
    if children := self._children_to_markdown().strip():
        return f'[Button: {children}]'
    return ''
```

Tests adjusted: empty `ui.button()` now renders `''` (was `'[Button]'`); two new cases cover aria-label and child-content rendering.

## Phase 2 cross-references

PR 4 of 5. See `mdp2-headings` for the full lineup.

**Composes with PR 3 (`mdp2-decorative-html`).** Standalone, PR 4 surfaces the raw phosphor HTML that previously hid behind `[Button]` — copy buttons render as `[Button: <i class="ph-duotone ph-copy"></i>]`. With PR 3 applied first, the phosphor children render empty and the copy-button noise collapses to `''`. Apply both for the full effect; PR 4 alone is a small win for buttons with meaningful child content (e.g. `with ui.button(): ui.label('Save')` becomes `[Button: Save]`).

## E2E results

`/documentation/section_text_elements` (baseline 428 lines, this PR alone):
- `[Button]` (bare, no label/icon) count: **11 → 0** ✓
- Total `[Button:` count: **2 → 13** (the increase represents copy-buttons that now expose their child content; with PR 3 applied first, this drops further as phosphor children render empty)

## Known gaps

- Public-API change: `ui.button()` (no args) used to render `'[Button]'` and now renders `''`. The associated test was updated. This is a tightening of behavior, not a breaking change of intent — empty markdown is the correct representation of a fully-empty decorative button.

## Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will…"
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the security advisory process.
- [x] Pytests have been added.
- [x] Documentation is not necessary for an underlying agent-facing change.
