### PR TITLE
Markdown Phase 2: convert ReST link / field-list syntax in docs markdown stream

### DIFF
--- a/tests/test_markdown_response.py
+++ b/tests/test_markdown_response.py
@@ -220,6 +220,23 @@ async def test_notification(user: User):
     await _assert_markdown(user, build, 'Page content\n\nHello notification!')
 
 
+def test_rest_link_conversion():
+    from website.documentation.custom_restructured_text import _rest_to_markdown
+    assert _rest_to_markdown('text with `Quasar Chat <https://quasar.dev/x>`_ component.') \
+        == 'text with [Quasar Chat](https://quasar.dev/x) component.'
+
+
+def test_rest_field_list_conversion():
+    from website.documentation.custom_restructured_text import _rest_to_markdown
+    rst = ':text: the message body\n:name: the message author'
+    assert _rest_to_markdown(rst) == '- **text**: the message body\n- **name**: the message author'
+
+
+def test_rest_passthrough_for_plain_text():
+    from website.documentation.custom_restructured_text import _rest_to_markdown
+    assert _rest_to_markdown('just a plain sentence.') == 'just a plain sentence.'
+
+
 async def _assert_markdown(user: User, build: Callable, expected: str) -> None:
     @ui.page('/', markdown=True)
     def _():

--- a/website/documentation/custom_restructured_text.py
+++ b/website/documentation/custom_restructured_text.py
@@ -1,5 +1,29 @@
+import re
+
 from nicegui import ui
 from nicegui.elements.restructured_text import prepare_content
+
+_REST_LINK = re.compile(r'`([^`<\n]+?)\s*<([^>\s]+)>`_')
+_REST_FIELD = re.compile(r'^:([^:\n]+):\s*(.*)$')
+
+
+def _rest_to_markdown(text: str) -> str:
+    """Convert a small subset of ReST syntax to markdown for the agent stream.
+
+    Currently handles:
+    - external links: ``Title <url>``_  ->  [Title](url)
+    - field lists: ``:name: text``       ->  - **name**: text
+    Everything else is passed through verbatim.
+    """
+    text = _REST_LINK.sub(r'[\1](\2)', text)
+    out_lines = []
+    for line in text.splitlines():
+        match = _REST_FIELD.match(line)
+        if match:
+            out_lines.append(f'- **{match.group(1).strip()}**: {match.group(2)}')
+        else:
+            out_lines.append(line)
+    return '\n'.join(out_lines)
 
 
 class CustomRestructuredText(ui.restructured_text):
@@ -9,3 +33,6 @@ class CustomRestructuredText(ui.restructured_text):
         html = prepare_content('__PLACEHOLDER__\n\n' + content).replace('<p>__PLACEHOLDER__</p>\n', '')
         if self._props.get('innerHTML') != html:
             self._props['innerHTML'] = html
+
+    def _render_markdown(self) -> str:
+        return _rest_to_markdown(self.content)


### PR DESCRIPTION
## Motivation

Phase 2 polish for #5889 (markdown content negotiation, merged 2026-04-24). Per discussion zauberzeug/nicegui#6007 finding 5: several element docstrings on nicegui.io are written in reStructuredText (ReST) and pass through verbatim into the markdown stream:

```
Based on Quasar's `Chat Message <https://quasar.dev/vue-components/chat/>`_ component.
```

```
:text: the content of the label
:target: page function, NiceGUI element on the same page or string …
```

The link syntax `` `Title <url>`_ `` and field lists `:name: text` aren't markdown-idiomatic. Agents can still parse them, but they're a friction point.

The discussion classifies this as content-side (the docstring sources themselves), but the markdown agent path is where it becomes most jarring. **This PR does a render-time conversion only — docstring sources are unchanged.**

## Implementation

`website/documentation/custom_restructured_text.py` gains a `_render_markdown` method that runs a small regex pass on the source content:

1. `` `Title <url>`_ `` → `[Title](url)`
2. `:name: text` (line-start) → `- **name**: text`

Three new unit tests in `tests/test_markdown_response.py` cover both rules and the no-op case.

## Phase 2 cross-references

PR 5 of 5. See `mdp2-headings` for the full lineup. Independent of PRs 1-4 (touches a separate website helper).

## E2E results

| URL | Metric | Before | After |
|---|---|---|---|
| `/documentation/section_text_elements` | `` `Title <url>`_ `` leaks | 4 | **0** |
| `/documentation/section_text_elements` | `^:field:` leaks | 24 | **0** |
| `/documentation/chat_message` | link leaks | 4 | **0** |
| `/documentation/chat_message` | field leaks | 17 | **0** |

Sample after:
- `Based on Quasar's [Chat Message](https://quasar.dev/vue-components/chat/) component.`
- `- **text**: the content of the label`

## Maturity: **EXPLORATORY**

Two-rule regex. Good enough for the docstring vocabulary observed on nicegui.io, but it is not a general ReST→markdown converter. Edge cases NOT handled:

- Multi-line field-list values (continuation lines lose association with the bullet).
- Field lists inside fenced code blocks would be (incorrectly) rewritten — not observed in current docstrings.
- Backtick links containing newlines or `>` inside the title.
- Anonymous external links `` `Title <url>`__ `` (double underscore).
- Other ReST inline markup: `` :role:`text` ``, substitution refs `|x|`, footnote refs.
- ReST directives (`.. note::`, `.. code-block::`, admonitions) — pass through verbatim.

A more robust approach would route through docutils, but that adds a dependency for a render path that's already ad-hoc; the regex is intentionally minimal.

## Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will…"
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the security advisory process.
- [x] Pytests have been added.
- [x] Documentation is not necessary for an underlying agent-facing change.
