### PR TITLE
Add httpxyz forward-compat advisory for 3.x

### DIFF
--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -1,3 +1,5 @@
+# Must run before any submodule does `import httpx`, so the httpxyz forward-compat advisory (#6024) sees clean state.
+from . import _httpxyz_compat  # noqa: F401, I001
 from . import binding, elements, html, run, storage, ui
 from .api_router import APIRouter
 from .app.app import App

--- a/nicegui/_httpxyz_compat.py
+++ b/nicegui/_httpxyz_compat.py
@@ -1,0 +1,30 @@
+"""Forward-compat advisory for httpxyz (#6024).
+
+httpxyz registers itself as `httpx` in `sys.modules` via `setdefault`, so
+`import httpx` resolves to httpxyz when httpxyz is imported first. If real
+httpx is imported before httpxyz, the alias becomes a no-op and the two
+modules sit side by side, breaking `isinstance` checks across libraries.
+
+When this module is imported it warns the user once if that conflict is
+present. NiceGUI 4.0 will depend exclusively on httpxyz; until then NiceGUI
+itself stays neutral and works with whichever module owns
+`sys.modules['httpx']`.
+"""
+from __future__ import annotations
+
+import sys
+import warnings
+
+_httpxyz = sys.modules.get('httpxyz')
+if _httpxyz is not None and sys.modules.get('httpx') is not _httpxyz:
+    warnings.warn(
+        'httpxyz is loaded but real httpx was imported first; '
+        'isinstance() checks against httpx types may silently fail on '
+        'objects from libraries that already use httpxyz. Move '
+        "'import httpxyz' to the very first line of your entry point. "
+        'NiceGUI 4.0 will depend exclusively on httpxyz; see '
+        'https://github.com/zauberzeug/nicegui/issues/6024.',
+        UserWarning,
+        stacklevel=3,
+    )
+del _httpxyz

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -478,7 +478,7 @@ class Element(Visibility):
     def move(self,
              target_container: Element | None = None,
              target_index: int = -1, *,
-             target_slot: str | None = None) -> None:
+             target_slot: str | None = None) -> Self:
         """Move the element to another container.
 
         :param target_container: container to move the element to (default: the parent container)
@@ -505,6 +505,7 @@ class Element(Visibility):
         parent_slot.children.insert(target_index, self)
 
         target_container.update()
+        return self
 
     def remove(self, element: Element | int) -> None:
         """Remove a child element.

--- a/nicegui/elements/audio.py
+++ b/nicegui/elements/audio.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from .mixins.source_element import SourceElement
 
@@ -33,7 +35,7 @@ class Audio(SourceElement, component='audio.js'):
         self._props.set_bool('muted', muted)
         self._props.set_bool('loop', loop)
 
-    def set_source(self, source: str | Path) -> None:
+    def set_source(self, source: str | Path) -> Self:
         return super().set_source(source)
 
     def seek(self, seconds: float) -> None:

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -60,14 +60,17 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
     def _text_to_model_text(self, text: str) -> None:
         self._props['label'] = text
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the dropdown."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the dropdown."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the dropdown."""
         self.value = not self.value
+        return self

--- a/nicegui/elements/choice_element.py
+++ b/nicegui/elements/choice_element.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from typing_extensions import Self
+
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
 
@@ -52,7 +54,7 @@ class ChoiceElement(ValueElement[Any]):
             self._update_options()
         super().update()
 
-    def set_options(self, options: list | dict, *, value: Any = ...) -> None:
+    def set_options(self, options: list | dict, *, value: Any = ...) -> Self:
         """Set the options of this choice element.
 
         :param options: The new options.
@@ -62,3 +64,4 @@ class ChoiceElement(ValueElement[Any]):
         if value is not ...:
             self.value = value
         self.update()
+        return self

--- a/nicegui/elements/codemirror/codemirror.py
+++ b/nicegui/elements/codemirror/codemirror.py
@@ -1,6 +1,8 @@
 from itertools import accumulate, chain, repeat
 from typing import Literal, get_args
 
+from typing_extensions import Self
+
 from ...defaults import DEFAULT_PROP, resolve_defaults
 from ...elements.mixins.disableable_element import DisableableElement
 from ...elements.mixins.value_element import ValueElement
@@ -310,9 +312,10 @@ class CodeMirror(ValueElement[str], DisableableElement,
     def theme(self, theme: SUPPORTED_THEMES) -> None:
         self._props['theme'] = theme
 
-    def set_theme(self, theme: SUPPORTED_THEMES) -> None:
+    def set_theme(self, theme: SUPPORTED_THEMES) -> Self:
         """Sets the theme of the editor."""
         self._props['theme'] = theme
+        return self
 
     @property
     def supported_themes(self) -> list[str]:
@@ -328,9 +331,10 @@ class CodeMirror(ValueElement[str], DisableableElement,
     def language(self, language: SUPPORTED_LANGUAGES | None = None) -> None:
         self._props['language'] = language
 
-    def set_language(self, language: SUPPORTED_LANGUAGES | None = None) -> None:
+    def set_language(self, language: SUPPORTED_LANGUAGES | None = None) -> Self:
         """Sets the language of the editor (case-insensitive)."""
         self._props['language'] = language
+        return self
 
     @property
     def supported_languages(self) -> list[str]:
@@ -349,12 +353,13 @@ class CodeMirror(ValueElement[str], DisableableElement,
     def line_wrapping(self, value: bool) -> None:
         self._props['line-wrapping'] = value
 
-    def set_line_wrapping(self, value: bool) -> None:
+    def set_line_wrapping(self, value: bool) -> Self:
         """Sets whether line wrapping is enabled.
 
         *Added in version 3.2.0*
         """
         self._props['line-wrapping'] = value
+        return self
 
     def _event_args_to_value(self, e: GenericEventArguments) -> str:
         """The event contains a change set which is applied to the current value."""

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -2,6 +2,8 @@ import re
 from colorsys import rgb_to_yiq
 from typing import Any
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .button import Button as button
@@ -46,11 +48,12 @@ class ColorInput(LabelElement, ValueElement[str | None], DisableableElement):
         self.preview = preview
         self._update_preview()
 
-    def open_picker(self) -> None:
+    def open_picker(self) -> Self:
         """Open the color picker"""
         if self.value:
             self.picker.set_color(self.value)
         self.picker.open()
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)

--- a/nicegui/elements/color_picker.py
+++ b/nicegui/elements/color_picker.py
@@ -29,12 +29,13 @@ class ColorPicker(Menu):
                     handle_event(handler, ColorPickEventArguments(sender=self, client=self.client, color=e.args))
             self.q_color = Element('q-color').on('change', handle_change)
 
-    def set_color(self, color: str) -> None:
+    def set_color(self, color: str) -> Self:
         """Set the color of the picker.
 
         :param color: the color to set
         """
         self.q_color.props(f'model-value="{color}"')
+        return self
 
     def on_pick(self, callback: Handler[ColorPickEventArguments]) -> Self:
         """Add a callback to be invoked when a color is picked."""

--- a/nicegui/elements/context_menu.py
+++ b/nicegui/elements/context_menu.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..element import Element
 
 
@@ -14,10 +16,12 @@ class ContextMenu(Element):
         self._props['context-menu'] = True
         self._props['touch-position'] = True
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the context menu."""
         self.run_method('show')
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the context menu."""
         self.run_method('hide')
+        return self

--- a/nicegui/elements/dark_mode.py
+++ b/nicegui/elements/dark_mode.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
@@ -23,15 +25,17 @@ class DarkMode(ValueElement[bool | None], component='dark_mode.js'):
         """
         super().__init__(value=value, on_value_change=on_change)
 
-    def enable(self) -> None:
+    def enable(self) -> Self:
         """Enable dark mode."""
         self.value = True
+        return self
 
-    def disable(self) -> None:
+    def disable(self) -> Self:
         """Disable dark mode."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle dark mode.
 
         This method will raise a ValueError if dark mode is set to auto.
@@ -39,10 +43,12 @@ class DarkMode(ValueElement[bool | None], component='dark_mode.js'):
         if self.value is None:
             raise ValueError('Cannot toggle dark mode when it is set to auto.')
         self.value = not self.value
+        return self
 
-    def auto(self) -> None:
+    def auto(self) -> Self:
         """Set dark mode to auto.
 
         This will use the client's system preference.
         """
         self.value = None
+        return self

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -2,13 +2,16 @@ import asyncio
 import weakref
 from typing import Any
 
+from typing_extensions import Self
+
 from ..context import context
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..element import Element
+from ..helpers import NoImplicitAwait
 from .mixins.value_element import ValueElement
 
 
-class Dialog(ValueElement[bool], component='dialog.js'):
+class Dialog(ValueElement[bool], NoImplicitAwait, component='dialog.js'):
 
     @resolve_defaults
     def __init__(self, *, value: bool = DEFAULT_PROPS['model-value'] | False) -> None:
@@ -44,13 +47,15 @@ class Dialog(ValueElement[bool], component='dialog.js'):
             self._submitted = asyncio.Event()
         return self._submitted
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the dialog."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the dialog."""
         self.value = False
+        return self
 
     def __await__(self):
         self._result = None

--- a/nicegui/elements/drawer.py
+++ b/nicegui/elements/drawer.py
@@ -1,5 +1,7 @@
 from typing import Any, Literal
 
+from typing_extensions import Self
+
 from ..context import context
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..helpers import require_top_level_layout
@@ -62,20 +64,23 @@ class Drawer(ValueElement[bool | None], default_classes='nicegui-drawer'):
                 )
             self.client.on_connect(_request_value)
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the drawer"""
         if self.value is None:
             self.run_method('toggle')
         else:
             self.value = not self.value
+        return self
 
-    def show(self) -> None:
+    def show(self) -> Self:
         """Show the drawer"""
         self.value = True
+        return self
 
-    def hide(self) -> None:
+    def hide(self) -> Self:
         """Hide the drawer"""
         self.value = False
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)

--- a/nicegui/elements/expansion.py
+++ b/nicegui/elements/expansion.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -34,13 +36,15 @@ class Expansion(SortableElement, IconElement, TextElement, ValueElement[bool], D
         self._props.set_optional('caption', caption)
         self._props.set_optional('group', group)
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the expansion."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the expansion."""
         self.value = False
+        return self
 
     def _render_markdown(self) -> str:
         parts = []

--- a/nicegui/elements/fab.py
+++ b/nicegui/elements/fab.py
@@ -37,17 +37,20 @@ class Fab(ValueElement[bool], LabelElement, IconElement, BackgroundColorElement,
         super().__init__(tag='q-fab', value=value, label=label, background_color=color, icon=icon)
         self._props['direction'] = direction
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the FAB."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the FAB."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the FAB."""
         self.value = not self.value
+        return self
 
 
 class FabAction(LabelElement, IconElement, BackgroundColorElement, DisableableElement):

--- a/nicegui/elements/footer.py
+++ b/nicegui/elements/footer.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..context import context
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..helpers import require_top_level_layout
@@ -42,14 +44,17 @@ class Footer(ValueElement[bool], default_classes='nicegui-footer'):
 
         self.move(target_index=-1)
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the footer"""
         self.value = not self.value
+        return self
 
-    def show(self) -> None:
+    def show(self) -> Self:
         """Show the footer"""
         self.value = True
+        return self
 
-    def hide(self) -> None:
+    def hide(self) -> Self:
         """Hide the footer"""
         self.value = False
+        return self

--- a/nicegui/elements/fullscreen.py
+++ b/nicegui/elements/fullscreen.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
@@ -45,17 +47,20 @@ class Fullscreen(ValueElement[bool], component='fullscreen.js'):
     def require_escape_hold(self, value: bool) -> None:
         self._props['require-escape-hold'] = value
 
-    def enter(self) -> None:
+    def enter(self) -> Self:
         """Enter fullscreen mode."""
         self.value = True
+        return self
 
-    def exit(self) -> None:
+    def exit(self) -> Self:
         """Exit fullscreen mode."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle fullscreen mode."""
         self.value = not self.value
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)

--- a/nicegui/elements/header.py
+++ b/nicegui/elements/header.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..context import context
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..helpers import require_top_level_layout
@@ -47,14 +49,17 @@ class Header(ValueElement[bool], component='header.js', default_classes='nicegui
 
         self._props.add_rename('add_scroll_padding', 'add-scroll-padding')  # DEPRECATED: remove in NiceGUI 4.0
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the header"""
         self.value = not self.value
+        return self
 
-    def show(self) -> None:
+    def show(self) -> Self:
         """Show the header"""
         self.value = True
+        return self
 
-    def hide(self) -> None:
+    def hide(self) -> Self:
         """Hide the header"""
         self.value = False
+        return self

--- a/nicegui/elements/image.py
+++ b/nicegui/elements/image.py
@@ -5,6 +5,8 @@ import time
 from contextlib import suppress
 from pathlib import Path
 
+from typing_extensions import Self
+
 from .. import optional_features
 from ..logging import log
 from .mixins.source_element import SourceElement
@@ -27,7 +29,7 @@ class Image(SourceElement, component='image.js'):
         """
         super().__init__(source=source)
 
-    def set_source(self, source: str | Path | PIL_Image) -> None:
+    def set_source(self, source: str | Path | PIL_Image) -> Self:
         return super().set_source(source)
 
     def _set_props(self, source: str | Path | PIL_Image) -> None:

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .icon import Icon
@@ -76,9 +78,10 @@ class Input(LabelElement, ValidationElement[str | None], DisableableElement, com
         if suffix is not None:
             self._props['suffix'] = suffix
 
-    def set_autocomplete(self, autocomplete: list[str] | None) -> None:
+    def set_autocomplete(self, autocomplete: list[str] | None) -> Self:
         """Set the autocomplete list."""
         self._props['_autocomplete'] = autocomplete
+        return self
 
     @property
     def prefix(self) -> str | None:

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -78,7 +78,7 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
         if on_mouse:
             self.on_mouse(on_mouse)
 
-    def set_source(self, source: str | Path | PIL_Image) -> None:
+    def set_source(self, source: str | Path | PIL_Image) -> Self:
         return super().set_source(source)
 
     def on_mouse(self, on_mouse: Handler[MouseEventArguments]) -> Self:

--- a/nicegui/elements/leaflet/leaflet.py
+++ b/nicegui/elements/leaflet/leaflet.py
@@ -116,17 +116,17 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
             return NullResponse()
         return super().run_method(name, *args, timeout=timeout)
 
-    def set_center(self, center: tuple[float, float]) -> None:
+    def set_center(self, center: tuple[float, float]) -> Self:
         """Set the center location of the map."""
-        if self._props['center'] == center:
-            return
-        self._props['center'] = center
+        if self._props['center'] != center:
+            self._props['center'] = center
+        return self
 
-    def set_zoom(self, zoom: int) -> None:
+    def set_zoom(self, zoom: int) -> Self:
         """Set the zoom level of the map."""
-        if self._props['zoom'] == zoom:
-            return
-        self._props['zoom'] = zoom
+        if self._props['zoom'] != zoom:
+            self._props['zoom'] = zoom
+        return self
 
     def remove_layer(self, layer: Layer) -> None:
         """Remove a layer from the map."""

--- a/nicegui/elements/leaflet/leaflet_layers.py
+++ b/nicegui/elements/leaflet/leaflet_layers.py
@@ -84,7 +84,7 @@ class Marker(Layer):
         self.options['draggable'] = value
         return self
 
-    def move(self, lat: float, lng: float) -> None:
+    def move(self, lat: float, lng: float) -> Self:
         """Move the marker to a new position.
 
         :param lat: latitude
@@ -92,3 +92,4 @@ class Marker(Layer):
         """
         self.latlng = (lat, lng)
         self.run_method('setLatLng', (lat, lng))
+        return self

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..events import ClickEventArguments, Handler
 from .context_menu import ContextMenu
@@ -29,17 +31,20 @@ class Menu(ValueElement[bool]):
     def _render_markdown(self) -> str:
         return self._children_to_markdown() if self.value else ''
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the menu."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the menu."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the menu."""
         self.value = not self.value
+        return self
 
 
 class MenuItem(Item):

--- a/nicegui/elements/mixins/color_elements.py
+++ b/nicegui/elements/mixins/color_elements.py
@@ -33,9 +33,10 @@ class BackgroundColorElement(Element):
         self.background_color = background_color
         self._handle_background_color_change(background_color)
 
-    def set_background_color(self, background_color: str | None) -> None:
+    def set_background_color(self, background_color: str | None) -> Self:
         """Set the background color of this element."""
         self.background_color = background_color
+        return self
 
     def _handle_background_color_change(self, background_color: str | None) -> None:
         # Clear previous color based on tracked state
@@ -140,9 +141,10 @@ class TextColorElement(Element):
         self.text_color = text_color
         self._handle_text_color_change(text_color)
 
-    def set_text_color(self, text_color: str | None) -> None:
+    def set_text_color(self, text_color: str | None) -> Self:
         """Set the text color of this element."""
         self.text_color = text_color
+        return self
 
     def _handle_text_color_change(self, text_color: str | None) -> None:
         # Clear previous color based on tracked state

--- a/nicegui/elements/mixins/content_element.py
+++ b/nicegui/elements/mixins/content_element.py
@@ -85,12 +85,13 @@ class ContentElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_content(self, content: str) -> None:
+    def set_content(self, content: str) -> Self:
         """Set the content of this element.
 
         :param content: The new content.
         """
         self.content = content
+        return self
 
     def _handle_content_change(self, content: str) -> None:
         """Called when the content of this element changes.

--- a/nicegui/elements/mixins/disableable_element.py
+++ b/nicegui/elements/mixins/disableable_element.py
@@ -23,13 +23,15 @@ class DisableableElement(Element):
             return True
         return not self.enabled and self.ignores_events_when_disabled
 
-    def enable(self) -> None:
+    def enable(self) -> Self:
         """Enable the element."""
         self.enabled = True
+        return self
 
-    def disable(self) -> None:
+    def disable(self) -> Self:
         """Disable the element."""
         self.enabled = False
+        return self
 
     def bind_enabled_to(self,
                         target_object: Any,
@@ -99,9 +101,10 @@ class DisableableElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_enabled(self, value: bool) -> None:
+    def set_enabled(self, value: bool) -> Self:
         """Set the enabled state of the element."""
         self.enabled = value
+        return self
 
     def _handle_enabled_change(self, enabled: bool) -> None:
         """Called when the element is enabled or disabled.

--- a/nicegui/elements/mixins/filter_element.py
+++ b/nicegui/elements/mixins/filter_element.py
@@ -85,12 +85,13 @@ class FilterElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_filter(self, filter_: str) -> None:
+    def set_filter(self, filter_: str) -> Self:
         """Set the filter of this element.
 
         :param filter: The new filter.
         """
         self.filter = filter_
+        return self
 
     def _handle_filter_change(self, filter_: str) -> None:
         """Called when the filter of this element changes.

--- a/nicegui/elements/mixins/icon_element.py
+++ b/nicegui/elements/mixins/icon_element.py
@@ -84,12 +84,13 @@ class IconElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_icon(self, icon: str | None) -> None:
+    def set_icon(self, icon: str | None) -> Self:
         """Set the icon of this element.
 
         :param icon: The new icon.
         """
         self.icon = icon
+        return self
 
     def _handle_icon_change(self, icon: str | None) -> None:
         """Called when the icon of this element changes.

--- a/nicegui/elements/mixins/label_element.py
+++ b/nicegui/elements/mixins/label_element.py
@@ -84,12 +84,13 @@ class LabelElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_label(self, label: str | None) -> None:
+    def set_label(self, label: str | None) -> Self:
         """Set the label of this element.
 
         :param label: The new label.
         """
         self.label = label
+        return self
 
     def _handle_label_change(self, label: str | None) -> None:
         """Called when the label of this element changes.

--- a/nicegui/elements/mixins/name_element.py
+++ b/nicegui/elements/mixins/name_element.py
@@ -84,12 +84,13 @@ class NameElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_name(self, name: str) -> None:
+    def set_name(self, name: str) -> Self:
         """Set the name of this element.
 
         :param name: The new name.
         """
         self.name = name
+        return self
 
     def _handle_name_change(self, name: str) -> None:
         """Called when the name of this element changes.

--- a/nicegui/elements/mixins/selectable_element.py
+++ b/nicegui/elements/mixins/selectable_element.py
@@ -105,12 +105,13 @@ class SelectableElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_selected(self, selected: bool) -> None:
+    def set_selected(self, selected: bool) -> Self:
         """Set the selection state of this element.
 
         :param selected: The new selection state.
         """
         self.selected = selected
+        return self
 
     def _handle_selection_change(self, selected: bool) -> None:
         """Called when the selection state of this element changes.

--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -91,12 +91,13 @@ class SourceElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_source(self, source: Any) -> None:
+    def set_source(self, source: Any) -> Self:
         """Set the source of this element.
 
         :param source: The new source.
         """
         self.source = source
+        return self
 
     def _handle_source_change(self, source: Any) -> None:
         """Called when the source of this element changes.

--- a/nicegui/elements/mixins/text_element.py
+++ b/nicegui/elements/mixins/text_element.py
@@ -84,12 +84,13 @@ class TextElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_text(self, text: str) -> None:
+    def set_text(self, text: str) -> Self:
         """Set the text of this element.
 
         :param text: The new text.
         """
         self.text = text
+        return self
 
     def _handle_text_change(self, text: str) -> None:
         """Called when the text of this element changes.

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -121,12 +121,13 @@ class ValueElement(Element, Generic[ValueT]):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_value(self, value: ValueT) -> None:
+    def set_value(self, value: ValueT) -> Self:
         """Set the value of this element.
 
         :param value: The value to set.
         """
         self.value = value
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         previous_value = self._props.get(self.VALUE_PROP)

--- a/nicegui/elements/mixins/visibility.py
+++ b/nicegui/elements/mixins/visibility.py
@@ -101,12 +101,13 @@ class Visibility:
              self_strict=False, other_strict=strict)
         return self
 
-    def set_visibility(self, visible: bool) -> None:
+    def set_visibility(self, visible: bool) -> Self:
         """Set the visibility of this element.
 
         :param visible: Whether the element should be visible.
         """
         self.visible = visible
+        return self
 
     def _handle_visibility_change(self, visible: str) -> None:
         """Called when the visibility of this element changes.

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -197,7 +197,7 @@ class Notification(Element, component='notification.js'):
         """Dismiss the notification."""
         self.run_method('dismiss')
 
-    def set_visibility(self, visible: bool) -> None:
+    def set_visibility(self, visible: bool) -> Self:
         raise NotImplementedError('Use `dismiss()` to remove the notification. See #3670 for more information.')
 
     def _render_markdown(self) -> str:

--- a/nicegui/elements/scene/scene_objects.py
+++ b/nicegui/elements/scene/scene_objects.py
@@ -1,5 +1,7 @@
 import math
 
+from typing_extensions import Self
+
 from .scene_object3d import Object3D
 
 
@@ -276,15 +278,17 @@ class Texture(Object3D):
         """
         super().__init__('texture', url, coordinates)
 
-    def set_url(self, url: str) -> None:
+    def set_url(self, url: str) -> Self:
         """Change the URL of the texture image."""
         self.args[0] = url
         self.scene.run_method('set_texture_url', self.id, url)
+        return self
 
-    def set_coordinates(self, coordinates: list[list[list[float] | None]]) -> None:
+    def set_coordinates(self, coordinates: list[list[list[float] | None]]) -> Self:
         """Change the texture coordinates."""
         self.args[1] = coordinates
         self.scene.run_method('set_texture_coordinates', self.id, coordinates)
+        return self
 
 
 class SpotLight(Object3D):
@@ -331,13 +335,14 @@ class PointCloud(Object3D):
         if colors is not None:
             self.material(color=None)
 
-    def set_points(self, points: list[list[float]], colors: list[list[float]] | None = None) -> None:
+    def set_points(self, points: list[list[float]], colors: list[list[float]] | None = None) -> Self:
         """Change the points and colors of the point cloud."""
         self.args[0] = points
         self.args[1] = colors
         self.scene.run_method('set_points', self.id, points, colors)
         if colors is not None:
             self.material(color=None)
+        return self
 
 
 class AxesHelper(Object3D):

--- a/nicegui/elements/slide_item.py
+++ b/nicegui/elements/slide_item.py
@@ -129,6 +129,7 @@ class SlideItem(DisableableElement):
                                                                                       side=e.args.get('side', side))))
         return self
 
-    def reset(self) -> None:
+    def reset(self) -> Self:
         """Reset the slide item to its initial state."""
         self.run_method('reset')
+        return self

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -379,12 +379,13 @@ class Table(FilterElement, component='table.js'):
     def selection(self, value: Literal[None, 'single', 'multiple']) -> None:
         self._props['selection'] = value or 'none'
 
-    def set_selection(self, value: Literal[None, 'single', 'multiple']) -> None:
+    def set_selection(self, value: Literal[None, 'single', 'multiple']) -> Self:
         """Set the selection type.
 
         *Added in version 2.11.0*
         """
         self.selection = value
+        return self
 
     @property
     def pagination(self) -> dict:
@@ -405,13 +406,15 @@ class Table(FilterElement, component='table.js'):
         """Set fullscreen mode."""
         self._props['fullscreen'] = value
 
-    def set_fullscreen(self, value: bool) -> None:
+    def set_fullscreen(self, value: bool) -> Self:
         """Set fullscreen mode."""
         self.is_fullscreen = value
+        return self
 
-    def toggle_fullscreen(self) -> None:
+    def toggle_fullscreen(self) -> Self:
         """Toggle fullscreen mode."""
         self.is_fullscreen = not self.is_fullscreen
+        return self
 
     def add_rows(self, rows: list[dict]) -> None:
         """Add rows to the table."""

--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -1,5 +1,7 @@
 from contextlib import AbstractContextManager, nullcontext
 
+from typing_extensions import Self
+
 from .. import core
 from ..client import Client, ClientConnectionTimeout
 from ..element import Element
@@ -48,5 +50,5 @@ class Timer(BaseTimer, Element, component='timer.js'):
             assert parent_slot is not None
             parent_slot.parent.remove(self)
 
-    def set_visibility(self, visible: bool) -> None:
+    def set_visibility(self, visible: bool) -> Self:
         raise NotImplementedError('Use `activate()`, `deactivate()` or `cancel()`. See #3670 for more information.')

--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -116,9 +116,10 @@ class Upload(LabelElement, DisableableElement, component='upload.js'):
         self.on('rejected', lambda: handle_event(callback, UiEventArguments(sender=self, client=self.client)), args=[])
         return self
 
-    def reset(self) -> None:
+    def reset(self) -> Self:
         """Clear the upload queue."""
         self.run_method('reset')
+        return self
 
     def _handle_delete(self) -> None:
         app.remove_route(self._props['url'])

--- a/nicegui/elements/video.py
+++ b/nicegui/elements/video.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from .mixins.source_element import SourceElement
 
@@ -33,7 +35,7 @@ class Video(SourceElement, component='video.js'):
         self._props.set_bool('muted', muted)
         self._props.set_bool('loop', loop)
 
-    def set_source(self, source: str | Path) -> None:
+    def set_source(self, source: str | Path) -> Self:
         return super().set_source(source)
 
     def seek(self, seconds: float) -> None:

--- a/nicegui/helpers/__init__.py
+++ b/nicegui/helpers/__init__.py
@@ -3,6 +3,7 @@ import os
 from .elements import require_top_level_layout
 from .files import hash_file_path, is_file
 from .functions import (
+    NoImplicitAwait,
     await_with_context,
     expects_arguments,
     is_coroutine_function,
@@ -14,6 +15,7 @@ from .strings import event_type_to_camel_case, kebab_to_camel_case, remove_inden
 from .warnings import warn_once
 
 __all__ = [
+    'NoImplicitAwait',
     'await_with_context',
     'event_type_to_camel_case',
     'expects_arguments',

--- a/nicegui/helpers/functions.py
+++ b/nicegui/helpers/functions.py
@@ -36,6 +36,10 @@ def expects_arguments(func: Callable) -> bool:
                for p in signature(func).parameters.values())
 
 
+class NoImplicitAwait:
+    """Marker base for awaitables that must not be implicitly awaited by event handlers."""
+
+
 def should_await(result: Any) -> TypeGuard[Awaitable[Any]]:
     """Determine if a result should be awaited.
 
@@ -43,8 +47,11 @@ def should_await(result: Any) -> TypeGuard[Awaitable[Any]]:
     (i.e. not an ``AwaitableResponse`` or an ``asyncio.Task``).
 
     Note: We want to await an awaitable result even if the handler is not an async function (like a lambda statement).
+
+    Subclasses of ``NoImplicitAwait`` are also excluded
+    so that chainable mutators returning ``self`` on awaitable elements (like ``Dialog``) are not silently awaited.
     """
-    return isinstance(result, Awaitable) and not isinstance(result, (AwaitableResponse, asyncio.Task))
+    return isinstance(result, Awaitable) and not isinstance(result, (NoImplicitAwait, AwaitableResponse, asyncio.Task))
 
 
 async def await_with_context(awaitable: Awaitable[_T], context: AbstractContextManager) -> _T:

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -76,61 +76,66 @@ class UserInteraction(Generic[T]):
 
     def click(self) -> Self:
         """Click the selected elements."""
+        if not (enabled_elements := [e for e in self.elements if not isinstance(e, DisableableElement) or e.enabled]):
+            return self
+        element = min(enabled_elements, key=lambda e: e.id)  # deterministically pick the element with the lowest ID
+
         assert self.user.client
         with self.user.client:
-            for element in self.elements:  # pylint: disable=too-many-nested-blocks
-                if isinstance(element, DisableableElement) and not element.enabled:
-                    continue
-                if isinstance(element, ui.link):
-                    self.user.navigate.to(element.props.get('href', '#'))
-                    return self
+            if isinstance(element, ui.link):
+                self._dispatch_click(element)
+                self.user.navigate.to(element.props.get('href', '#'))
 
-                if isinstance(element, ui.select):
-                    if element.is_showing_popup:
-                        _NOT_FOUND = object()
-                        if isinstance(element.options, dict):
-                            target_value = next((k for k, v in element.options.items() if v == self.target), _NOT_FOUND)
-                        else:
-                            target_value = self.target if self.target in element._values else _NOT_FOUND  # pylint: disable=protected-access
-                        if target_value is not _NOT_FOUND:
-                            # User clicked on a valid option: update the value and close the popup
-                            if element.multiple:
-                                if target_value in element.value:
-                                    element.value = [v for v in element.value if v != target_value]
-                                else:
-                                    element.value = [*element.value, target_value]
+            elif isinstance(element, ui.select):
+                if element.is_showing_popup:
+                    _NOT_FOUND = object()
+                    if isinstance(element.options, dict):
+                        target_value = next((k for k, v in element.options.items() if v == self.target), _NOT_FOUND)
+                    else:
+                        target_value = self.target if self.target in element._values else _NOT_FOUND  # pylint: disable=protected-access
+                    if target_value is not _NOT_FOUND:
+                        # User clicked on a valid option: update the value and close the popup
+                        if element.multiple:
+                            if target_value in element.value:
+                                element.value = [v for v in element.value if v != target_value]
                             else:
-                                element.value = target_value
-                                element._is_showing_popup = False  # pylint: disable=protected-access
+                                element.value = [*element.value, target_value]
                         else:
-                            # User clicked the select itself (not a valid option): just close the popup
+                            element.value = target_value
                             element._is_showing_popup = False  # pylint: disable=protected-access
                     else:
-                        element._is_showing_popup = True  # pylint: disable=protected-access
-                    return self
-                elif isinstance(element, ui.radio):
-                    if isinstance(element.options, dict):
-                        target_value = next((k for k, v in element.options.items() if v == self.target), '')
-                    else:
-                        target_value = self.target
-                    element.value = target_value
-                    return self
+                        # User clicked the select itself (not a valid option): just close the popup
+                        element._is_showing_popup = False  # pylint: disable=protected-access
+                        self._dispatch_click(element)
+                else:
+                    element._is_showing_popup = True  # pylint: disable=protected-access
+                    self._dispatch_click(element)
 
-                elif isinstance(element, ui.tab):
-                    if element.tabs is not None:  # DEPRECATED: check not needed once ui.tab requires a ui.tabs ancestor
-                        element.tabs.value = element.props['name']
-                    return self
+            elif isinstance(element, ui.radio):
+                if isinstance(element.options, dict):
+                    target_value = next((k for k, v in element.options.items() if v == self.target), '')
+                else:
+                    target_value = self.target
+                element.value = target_value
 
-                elif isinstance(element, ui.tree) and isinstance(self.target, str):
-                    NODE_KEY = element.props.get('node-key')
-                    LABEL_KEY = element.props.get('label-key')
-                    target_key = next((
-                        node[NODE_KEY]
-                        for node in element.nodes(visible=True)
-                        if self.target == node.get(LABEL_KEY)
-                    ), None)
-                    if target_key is None:
-                        return self
+            elif isinstance(element, ui.tab):
+                if element.tabs is not None:  # DEPRECATED: check not needed once ui.tab requires a ui.tabs ancestor
+                    element.tabs.value = element.props['name']
+                self._dispatch_click(element)
+
+            elif isinstance(element, (ui.checkbox, ui.switch)):
+                element.value = not element.value
+                self._dispatch_click(element)
+
+            elif isinstance(element, ui.tree) and isinstance(self.target, str):
+                NODE_KEY = element.props.get('node-key')
+                LABEL_KEY = element.props.get('label-key')
+                target_key = next((
+                    node[NODE_KEY]
+                    for node in element.nodes(visible=True)
+                    if self.target == node.get(LABEL_KEY)
+                ), None)
+                if target_key is not None:
                     expanded_set = set(element.props.get('expanded', [node[NODE_KEY] for node in element.nodes()]))
                     if target_key in expanded_set:
                         expanded_set.remove(target_key)
@@ -138,17 +143,21 @@ class UserInteraction(Generic[T]):
                         expanded_set.add(target_key)
                     element.props['expanded'] = list(expanded_set)
                     element.update()
-                    return self
 
-                for listener in element._event_listeners.values():  # pylint: disable=protected-access
-                    if listener.element_id != element.id:
-                        continue
-                    args = not element.value if isinstance(element, (ui.checkbox, ui.switch)) else None
-                    event_arguments = events.GenericEventArguments(sender=element, client=self.user.client, args=args)
-                    events.handle_event(listener.handler, event_arguments)
-                    if element.is_deleted:
-                        break
+            else:
+                self._dispatch_click(element)
+
         return self
+
+    def _dispatch_click(self, element: ui.element) -> None:
+        assert self.user.client
+        for listener in element._event_listeners.values():  # pylint: disable=protected-access
+            if listener.element_id != element.id or listener.type != 'click':
+                continue
+            event_arguments = events.GenericEventArguments(sender=element, client=self.user.client, args=None)
+            events.handle_event(listener.handler, event_arguments)
+            if element.is_deleted:
+                break
 
     def clear(self) -> Self:
         """Clear the selected elements.

--- a/tests/test_httpxyz_forward_compat.py
+++ b/tests/test_httpxyz_forward_compat.py
@@ -1,0 +1,86 @@
+"""Tests for the httpxyz forward-compat advisory in ``nicegui/__init__.py``.
+
+Run each scenario in a fresh subprocess so the import-order check in
+``nicegui/__init__.py`` sees a clean ``sys.modules``. ``-W default`` ensures
+warnings are emitted to stderr where the test can assert on them.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+WARNING_FRAGMENT = 'httpxyz is loaded but real httpx was imported first'
+
+httpxyz_available = importlib.util.find_spec('httpxyz') is not None
+needs_httpxyz = pytest.mark.skipif(not httpxyz_available, reason='httpxyz not installed')
+
+
+def _run(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, '-W', 'default', '-c', textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_no_httpxyz_no_warning() -> None:
+    """When httpxyz is not imported, NiceGUI must stay silent."""
+    result = _run('import nicegui  # noqa: F401')
+    assert result.returncode == 0, result.stderr
+    assert WARNING_FRAGMENT not in result.stderr
+
+
+@needs_httpxyz
+def test_httpxyz_first_no_warning() -> None:
+    """When httpxyz is imported before httpx, the alias is intact and we stay silent."""
+    result = _run('''
+        import httpxyz  # noqa: F401
+        import nicegui  # noqa: F401
+    ''')
+    assert result.returncode == 0, result.stderr
+    assert WARNING_FRAGMENT not in result.stderr
+
+
+@needs_httpxyz
+def test_real_httpx_first_warns() -> None:
+    """When real httpx is imported before httpxyz, the alias fails and we warn."""
+    result = _run('''
+        import httpx  # noqa: F401
+        import httpxyz  # noqa: F401
+        import nicegui  # noqa: F401
+    ''')
+    assert result.returncode == 0, result.stderr
+    assert WARNING_FRAGMENT in result.stderr
+    # The actionable payload must survive any future copy-edits to the warning.
+    assert 'first line of your entry point' in result.stderr
+    assert 'https://github.com/zauberzeug/nicegui/issues/6024' in result.stderr
+
+
+@needs_httpxyz
+def test_warning_points_at_user_code_not_nicegui() -> None:
+    """``stacklevel`` must point at the caller's ``import nicegui``, not at ``nicegui/__init__.py``."""
+    result = _run('''
+        import warnings
+        warnings.simplefilter("always")
+        import httpx  # noqa: F401
+        import httpxyz  # noqa: F401
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            import nicegui  # noqa: F401
+        for w in caught:
+            if "httpxyz" in str(w.message):
+                # filename should be the -c script (\"<string>\"), not somewhere inside the nicegui package
+                assert "nicegui" not in w.filename, f"warning points inside the package: {w.filename}"
+                print("STACKLEVEL_OK", w.filename)
+                break
+        else:
+            raise AssertionError("expected httpxyz warning was not captured")
+    ''')
+    assert result.returncode == 0, result.stderr
+    assert 'STACKLEVEL_OK' in result.stdout

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -192,7 +192,8 @@ async def test_notification(user: User) -> None:
 async def test_checkbox_and_switch(user: User, kind: type) -> None:
     @ui.page('/')
     def page():
-        element = kind('my element', on_change=lambda e: ui.notify(f'Changed: {e.value}'))
+        element = kind('my element', on_change=lambda e: ui.notify(f'Changed: {e.value}')) \
+            .on('click', lambda e: ui.notify(f'Clicked: {e.sender.value}'))
         ui.label().bind_text_from(element, 'value', lambda v: 'enabled' if v else 'disabled')
 
     await user.open('/')
@@ -201,10 +202,12 @@ async def test_checkbox_and_switch(user: User, kind: type) -> None:
     user.find('element').click()
     await user.should_see('enabled')
     await user.should_see('Changed: True')
+    await user.should_see('Clicked: True')
 
     user.find('element').click()
     await user.should_see('disabled')
     await user.should_see('Changed: False')
+    await user.should_see('Clicked: False')
 
 
 @pytest.mark.parametrize('kind', [ui.input, ui.editor, ui.codemirror])
@@ -351,7 +354,7 @@ async def test_trigger_with_event_arguments(user: User, args_value: Any, expecte
 async def test_click_link(user: User) -> None:
     @ui.page('/')
     def page():
-        ui.link('go to other', '/other')
+        ui.link('go to other', '/other').on('click', lambda: ui.notify('Link clicked'))
 
     @ui.page('/other')
     def other():
@@ -359,6 +362,7 @@ async def test_click_link(user: User) -> None:
 
     await user.open('/')
     user.find('go to other').click()
+    await user.should_see('Link clicked')
     await user.should_see('Other page')
 
 
@@ -569,6 +573,27 @@ async def test_select_none_value(user: User) -> None:
     user.find(ui.select).click()
     user.find('B').click()
     await user.should_see('Value: None')
+
+
+async def test_select_click_handler(user: User) -> None:
+    clicks = []
+
+    @ui.page('/')
+    def _():
+        ui.select(['A', 'B', 'C']).on('click', lambda: clicks.append('click'))
+
+    await user.open('/')
+    user.find(ui.select).click()
+    assert len(clicks) == 1, 'Opening select should fire click handler'
+
+    user.find('B').click()
+    assert len(clicks) == 1, 'Clicking option should not fire click handler'
+
+    user.find(ui.select).click()
+    assert len(clicks) == 2, 'Opening select should fire click handler again'
+
+    user.find(ui.select).click()
+    assert len(clicks) == 3, 'Closing select should fire click handler'
 
 
 async def test_upload_table(user: User) -> None:
@@ -884,6 +909,18 @@ async def test_switching_tabs_wrapped_in_row(user: User) -> None:
     await user.open('/')
     user.find('A').click()
     await user.should_see('Switching to A')
+
+
+async def test_tab_click_handler(user: User) -> None:
+    @ui.page('/')
+    def _():
+        with ui.tabs():
+            ui.tab('A').on('click', lambda: ui.notify('A clicked'))
+            ui.tab('B')
+
+    await user.open('/')
+    user.find('A').click()
+    await user.should_see('A clicked')
 
 
 async def test_clearing_container_with_button_inside(user: User) -> None:


### PR DESCRIPTION
### Motivation

Grace-period complement to the planned 4.0 migration to httpxyz ([#6024](https://github.com/zauberzeug/nicegui/issues/6024)).

httpxyz registers itself as `httpx` in `sys.modules` via `setdefault`, so `import httpx` resolves to httpxyz when httpxyz is imported first. If real httpx is imported before httpxyz, the alias becomes a no-op and the two modules sit side by side, breaking `isinstance` checks across libraries that have switched to httpxyz.

The full migration story we're aiming at:
- **3.x:** NiceGUI stays neutral. Internals continue to use `import httpx`, picking up whichever module owns the slot. Users who want forward-compat add `import httpxyz` as the first line of their entry point — that one line aliases httpx -> httpxyz process-wide for *all* libraries (NiceGUI, anthropic, openai, etc.), not just NiceGUI.
- **4.0** ([Falko's plan in #6024](https://github.com/zauberzeug/nicegui/issues/6024)): NiceGUI internals switch to `import httpxyz` natively, drop httpx from deps, re-type public API. Hard cut.

This PR adds a narrow runtime nudge in 3.x for the only case worth catching automatically: the user has clearly opted into httpxyz (it's loaded), but their import order made the alias a no-op.

### Implementation

- `nicegui/_httpxyz_compat.py` (new): runs once on import. If `sys.modules['httpxyz']` exists but `sys.modules['httpx']` is something else, emit a `UserWarning` pointing at the one-line fix and at #6024. Inlined at module top-level (no wrapper function) so the `stacklevel=3` correctly points at the user's `import nicegui` line, not at NiceGUI internals.
- `nicegui/__init__.py`: imports `_httpxyz_compat` first, on its own line above the existing tuple import, with a comment explaining the ordering invariant. `# noqa: F401, I001` keeps the linter happy without merging into the tuple (which would make the ordering-runs-first invariant accidental rather than intentional).
- `tests/test_httpxyz_forward_compat.py` (new): four subprocess-isolated scenarios covering no-httpxyz (silent), httpxyz-first (silent), httpx-then-httpxyz (warns), and a stacklevel test asserting the warning's `filename` is *not* inside the `nicegui/` package. Tests skip cleanly when httpxyz is not installed.

### What this PR explicitly does *not* do

We considered and rejected several more-aggressive detection mechanisms after a long design pass:

- **Probing `importlib.metadata.distribution('httpx')`** to flag "httpx exists on disk anywhere" — too noisy for non-venv users for whom httpx is a transitive dep of unrelated libraries.
- **Installing a `sys.meta_path` finder** to catch late `import httpx` (in functions, transitively) — would catch the in-function newbie pattern, but means a UI library mutates the global import system, with false positives from any library that lazily imports httpx.
- **NiceGUI proactively `import httpxyz` at startup** — would auto-alias for users with httpxyz installed, but adds the kind of import-time magic Falko's "simplicity over cleverness" prefers to avoid. Saved for 4.0's native switch instead.

The kept warning is the smallest signal that's both actionable and unambiguous: only fires when there's an actual in-process conflict the user can fix with one line of code.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary. <!-- The warning text itself + #6024 link is the docs surface. Open question: does this also deserve a section in the migration / release notes? -->
- [x] No breaking changes to the public API.