### PR TITLE
Add httpxyz forward-compat advisory for 3.x

### DIFF
--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -1,3 +1,5 @@
+# Must run before any submodule does `import httpx`, so the httpxyz forward-compat advisory (#6024) sees clean state.
+from . import _httpxyz_compat  # noqa: F401, I001
 from . import binding, elements, html, run, storage, ui
 from .api_router import APIRouter
 from .app.app import App

--- a/nicegui/_httpxyz_compat.py
+++ b/nicegui/_httpxyz_compat.py
@@ -3,8 +3,9 @@ import sys
 import warnings
 
 # httpxyz registers itself as `httpx` in `sys.modules` via `setdefault` (no-op if real
-# httpx was imported first). NiceGUI 4.0 will require httpxyz; until then we stay
-# neutral and just warn when real httpx is loaded so the user can prepare with one line.
+# httpx was imported first). NiceGUI 4.0 will require httpxyz; until then we warn when
+# real httpx already owns the slot, and otherwise try to load httpxyz so cold users
+# get auto-forward-compat for free.
 _httpxyz = sys.modules.get('httpxyz')
 _httpx = sys.modules.get('httpx')
 if _httpx is not None and _httpx is not _httpxyz:
@@ -17,4 +18,9 @@ if _httpx is not None and _httpx is not _httpxyz:
         UserWarning,
         stacklevel=3,
     )
+else:
+    try:
+        import httpxyz  # noqa: F401
+    except ImportError:
+        pass
 del _httpxyz, _httpx

--- a/nicegui/_httpxyz_compat.py
+++ b/nicegui/_httpxyz_compat.py
@@ -1,14 +1,15 @@
 """Forward-compat advisory for httpxyz (#6024).
 
 httpxyz registers itself as `httpx` in `sys.modules` via `setdefault`, so
-`import httpx` resolves to httpxyz when httpxyz is imported first. If real
-httpx is imported before httpxyz, the alias becomes a no-op and the two
-modules sit side by side, breaking `isinstance` checks across libraries.
+`import httpx` resolves to httpxyz when httpxyz is imported first. NiceGUI
+4.0 will depend exclusively on httpxyz; until then NiceGUI itself stays
+neutral and works with whichever module owns `sys.modules['httpx']`.
 
-When this module is imported it warns the user once if that conflict is
-present. NiceGUI 4.0 will depend exclusively on httpxyz; until then NiceGUI
-itself stays neutral and works with whichever module owns
-`sys.modules['httpx']`.
+When this module is imported it warns the user once if real httpx is loaded
+in this process — i.e. the user (or a library they imported before NiceGUI)
+is using real httpx, and adding `import httpxyz` as the first line of their
+entry point would prepare them for 4.0 and route every HTTP library through
+the same stack today.
 """
 from __future__ import annotations
 
@@ -16,15 +17,17 @@ import sys
 import warnings
 
 _httpxyz = sys.modules.get('httpxyz')
-if _httpxyz is not None and sys.modules.get('httpx') is not _httpxyz:
+_httpx = sys.modules.get('httpx')
+if _httpx is not None and _httpx is not _httpxyz:
     warnings.warn(
-        'httpxyz is loaded but real httpx was imported first; '
-        'isinstance() checks against httpx types may silently fail on '
-        'objects from libraries that already use httpxyz. Move '
-        "'import httpxyz' to the very first line of your entry point. "
-        'NiceGUI 4.0 will depend exclusively on httpxyz; see '
-        'https://github.com/zauberzeug/nicegui/issues/6024.',
+        'Real httpx is loaded in this process. NiceGUI 4.0 will depend '
+        'exclusively on httpxyz; add '
+        "'import httpxyz' "
+        'as the first line of your entry point (installing httpxyz first if '
+        'needed) to alias httpx -> httpxyz process-wide so every HTTP '
+        'library (NiceGUI, anthropic, openai, ...) routes through the same '
+        'stack. See https://github.com/zauberzeug/nicegui/issues/6024.',
         UserWarning,
         stacklevel=3,
     )
-del _httpxyz
+del _httpxyz, _httpx

--- a/nicegui/_httpxyz_compat.py
+++ b/nicegui/_httpxyz_compat.py
@@ -20,7 +20,7 @@ if _httpx is not None and _httpx is not _httpxyz:
     )
 else:
     try:
-        import httpxyz  # noqa: F401
+        import httpxyz  # noqa: F401  # pylint: disable=unused-import
     except ImportError:
         pass
 del _httpxyz, _httpx

--- a/nicegui/_httpxyz_compat.py
+++ b/nicegui/_httpxyz_compat.py
@@ -1,0 +1,30 @@
+"""Forward-compat advisory for httpxyz (#6024).
+
+httpxyz registers itself as `httpx` in `sys.modules` via `setdefault`, so
+`import httpx` resolves to httpxyz when httpxyz is imported first. If real
+httpx is imported before httpxyz, the alias becomes a no-op and the two
+modules sit side by side, breaking `isinstance` checks across libraries.
+
+When this module is imported it warns the user once if that conflict is
+present. NiceGUI 4.0 will depend exclusively on httpxyz; until then NiceGUI
+itself stays neutral and works with whichever module owns
+`sys.modules['httpx']`.
+"""
+from __future__ import annotations
+
+import sys
+import warnings
+
+_httpxyz = sys.modules.get('httpxyz')
+if _httpxyz is not None and sys.modules.get('httpx') is not _httpxyz:
+    warnings.warn(
+        'httpxyz is loaded but real httpx was imported first; '
+        'isinstance() checks against httpx types may silently fail on '
+        'objects from libraries that already use httpxyz. Move '
+        "'import httpxyz' to the very first line of your entry point. "
+        'NiceGUI 4.0 will depend exclusively on httpxyz; see '
+        'https://github.com/zauberzeug/nicegui/issues/6024.',
+        UserWarning,
+        stacklevel=3,
+    )
+del _httpxyz

--- a/nicegui/_httpxyz_compat.py
+++ b/nicegui/_httpxyz_compat.py
@@ -1,21 +1,10 @@
-"""Forward-compat advisory for httpxyz (#6024).
-
-httpxyz registers itself as `httpx` in `sys.modules` via `setdefault`, so
-`import httpx` resolves to httpxyz when httpxyz is imported first. NiceGUI
-4.0 will depend exclusively on httpxyz; until then NiceGUI itself stays
-neutral and works with whichever module owns `sys.modules['httpx']`.
-
-When this module is imported it warns the user once if real httpx is loaded
-in this process — i.e. the user (or a library they imported before NiceGUI)
-is using real httpx, and adding `import httpxyz` as the first line of their
-entry point would prepare them for 4.0 and route every HTTP library through
-the same stack today.
-"""
-from __future__ import annotations
-
+"""httpxyz forward-compat advisory; see https://github.com/zauberzeug/nicegui/issues/6024."""
 import sys
 import warnings
 
+# httpxyz registers itself as `httpx` in `sys.modules` via `setdefault` (no-op if real
+# httpx was imported first). NiceGUI 4.0 will require httpxyz; until then we stay
+# neutral and just warn when real httpx is loaded so the user can prepare with one line.
 _httpxyz = sys.modules.get('httpxyz')
 _httpx = sys.modules.get('httpx')
 if _httpx is not None and _httpx is not _httpxyz:

--- a/nicegui/_httpxyz_compat.py
+++ b/nicegui/_httpxyz_compat.py
@@ -20,13 +20,11 @@ _httpxyz = sys.modules.get('httpxyz')
 _httpx = sys.modules.get('httpx')
 if _httpx is not None and _httpx is not _httpxyz:
     warnings.warn(
-        'Real httpx is loaded in this process. NiceGUI 4.0 will depend '
-        'exclusively on httpxyz; add '
-        "'import httpxyz' "
-        'as the first line of your entry point (installing httpxyz first if '
-        'needed) to alias httpx -> httpxyz process-wide so every HTTP '
-        'library (NiceGUI, anthropic, openai, ...) routes through the same '
-        'stack. See https://github.com/zauberzeug/nicegui/issues/6024.',
+        'Real httpx is loaded in this process. NiceGUI 4.0 will require '
+        "httpxyz; install and 'import httpxyz' as the first line of your "
+        'entry point. This aliases httpx -> httpxyz process-wide so every '
+        'HTTP library (NiceGUI, anthropic, openai, ...) uses httpxyz. See '
+        'https://github.com/zauberzeug/nicegui/issues/6024.',
         UserWarning,
         stacklevel=3,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ check_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = [
+    "httpxyz",
     "markdown2",
     "matplotlib.*",
     "nicegui_highcharts",

--- a/tests/test_httpxyz_forward_compat.py
+++ b/tests/test_httpxyz_forward_compat.py
@@ -15,42 +15,21 @@ def _run(code):
                           capture_output=True, text=True, timeout=60, check=False)
 
 
-def test_cold_import_nicegui_no_warning():
-    result = _run('import nicegui')
+@pytest.mark.parametrize('setup, expect_warning', [
+    pytest.param('import nicegui', False, id='cold'),
+    pytest.param('import httpxyz; import nicegui', False, id='httpxyz-first', marks=needs_httpxyz),
+    pytest.param('import httpx; import nicegui', True, id='httpx-only'),
+    pytest.param('import httpx; import httpxyz; import nicegui', True, id='httpx-then-httpxyz', marks=needs_httpxyz),
+])
+def test_warning_fires_iff_real_httpx_loaded(setup, expect_warning):
+    result = _run(setup)
     assert result.returncode == 0, result.stderr
-    assert WARNING_FRAGMENT not in result.stderr
-
-
-@needs_httpxyz
-def test_httpxyz_first_no_warning():
-    result = _run('''
-        import httpxyz
-        import nicegui
-    ''')
-    assert result.returncode == 0, result.stderr
-    assert WARNING_FRAGMENT not in result.stderr
-
-
-def test_real_httpx_loaded_warns_without_httpxyz():
-    result = _run('''
-        import httpx
-        import nicegui
-    ''')
-    assert result.returncode == 0, result.stderr
-    assert WARNING_FRAGMENT in result.stderr
-    assert 'first line of your entry point' in result.stderr
-    assert 'https://github.com/zauberzeug/nicegui/issues/6024' in result.stderr
-
-
-@needs_httpxyz
-def test_real_httpx_with_late_httpxyz_warns():
-    result = _run('''
-        import httpx
-        import httpxyz
-        import nicegui
-    ''')
-    assert result.returncode == 0, result.stderr
-    assert WARNING_FRAGMENT in result.stderr
+    if expect_warning:
+        assert WARNING_FRAGMENT in result.stderr
+        assert 'first line of your entry point' in result.stderr
+        assert 'https://github.com/zauberzeug/nicegui/issues/6024' in result.stderr
+    else:
+        assert WARNING_FRAGMENT not in result.stderr
 
 
 def test_warning_points_at_user_code_not_nicegui():

--- a/tests/test_httpxyz_forward_compat.py
+++ b/tests/test_httpxyz_forward_compat.py
@@ -1,0 +1,86 @@
+"""Tests for the httpxyz forward-compat advisory in ``nicegui/__init__.py``.
+
+Run each scenario in a fresh subprocess so the import-order check in
+``nicegui/__init__.py`` sees a clean ``sys.modules``. ``-W default`` ensures
+warnings are emitted to stderr where the test can assert on them.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+WARNING_FRAGMENT = 'httpxyz is loaded but real httpx was imported first'
+
+httpxyz_available = importlib.util.find_spec('httpxyz') is not None
+needs_httpxyz = pytest.mark.skipif(not httpxyz_available, reason='httpxyz not installed')
+
+
+def _run(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, '-W', 'default', '-c', textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_no_httpxyz_no_warning() -> None:
+    """When httpxyz is not imported, NiceGUI must stay silent."""
+    result = _run('import nicegui  # noqa: F401')
+    assert result.returncode == 0, result.stderr
+    assert WARNING_FRAGMENT not in result.stderr
+
+
+@needs_httpxyz
+def test_httpxyz_first_no_warning() -> None:
+    """When httpxyz is imported before httpx, the alias is intact and we stay silent."""
+    result = _run('''
+        import httpxyz  # noqa: F401
+        import nicegui  # noqa: F401
+    ''')
+    assert result.returncode == 0, result.stderr
+    assert WARNING_FRAGMENT not in result.stderr
+
+
+@needs_httpxyz
+def test_real_httpx_first_warns() -> None:
+    """When real httpx is imported before httpxyz, the alias fails and we warn."""
+    result = _run('''
+        import httpx  # noqa: F401
+        import httpxyz  # noqa: F401
+        import nicegui  # noqa: F401
+    ''')
+    assert result.returncode == 0, result.stderr
+    assert WARNING_FRAGMENT in result.stderr
+    # The actionable payload must survive any future copy-edits to the warning.
+    assert 'first line of your entry point' in result.stderr
+    assert 'https://github.com/zauberzeug/nicegui/issues/6024' in result.stderr
+
+
+@needs_httpxyz
+def test_warning_points_at_user_code_not_nicegui() -> None:
+    """``stacklevel`` must point at the caller's ``import nicegui``, not at ``nicegui/__init__.py``."""
+    result = _run('''
+        import warnings
+        warnings.simplefilter("always")
+        import httpx  # noqa: F401
+        import httpxyz  # noqa: F401
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            import nicegui  # noqa: F401
+        for w in caught:
+            if "httpxyz" in str(w.message):
+                # filename should be the -c script (\"<string>\"), not somewhere inside the nicegui package
+                assert "nicegui" not in w.filename, f"warning points inside the package: {w.filename}"
+                print("STACKLEVEL_OK", w.filename)
+                break
+        else:
+            raise AssertionError("expected httpxyz warning was not captured")
+    ''')
+    assert result.returncode == 0, result.stderr
+    assert 'STACKLEVEL_OK' in result.stdout

--- a/tests/test_httpxyz_forward_compat.py
+++ b/tests/test_httpxyz_forward_compat.py
@@ -1,94 +1,73 @@
-"""Tests for the httpxyz forward-compat advisory in ``nicegui/__init__.py``.
-
-Run each scenario in a fresh subprocess so the import-order check in
-``nicegui/__init__.py`` sees a clean ``sys.modules``. ``-W default`` ensures
-warnings are emitted to stderr where the test can assert on them.
-"""
-from __future__ import annotations
-
-import importlib.util
 import subprocess
 import sys
-import textwrap
+from importlib.util import find_spec
+from textwrap import dedent
 
 import pytest
 
 WARNING_FRAGMENT = 'Real httpx is loaded in this process'
 
-httpxyz_available = importlib.util.find_spec('httpxyz') is not None
-needs_httpxyz = pytest.mark.skipif(not httpxyz_available, reason='httpxyz not installed')
+needs_httpxyz = pytest.mark.skipif(find_spec('httpxyz') is None, reason='httpxyz not installed')
 
 
-def _run(code: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [sys.executable, '-W', 'default', '-c', textwrap.dedent(code)],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-    )
+def _run(code):
+    return subprocess.run([sys.executable, '-W', 'default', '-c', dedent(code)],
+                          capture_output=True, text=True, timeout=60, check=False)
 
 
-def test_cold_import_nicegui_no_warning() -> None:
-    """A bare ``import nicegui`` with no prior httpx/httpxyz must stay silent."""
-    result = _run('import nicegui  # noqa: F401')
+def test_cold_import_nicegui_no_warning():
+    result = _run('import nicegui')
     assert result.returncode == 0, result.stderr
     assert WARNING_FRAGMENT not in result.stderr
 
 
 @needs_httpxyz
-def test_httpxyz_first_no_warning() -> None:
-    """When httpxyz is imported before httpx, the alias is intact and we stay silent."""
+def test_httpxyz_first_no_warning():
     result = _run('''
-        import httpxyz  # noqa: F401
-        import nicegui  # noqa: F401
+        import httpxyz
+        import nicegui
     ''')
     assert result.returncode == 0, result.stderr
     assert WARNING_FRAGMENT not in result.stderr
 
 
-def test_real_httpx_loaded_warns_without_httpxyz() -> None:
-    """When real httpx is loaded but httpxyz is not, we still warn — that user is the migration target."""
+def test_real_httpx_loaded_warns_without_httpxyz():
     result = _run('''
-        import httpx  # noqa: F401
-        import nicegui  # noqa: F401
+        import httpx
+        import nicegui
     ''')
     assert result.returncode == 0, result.stderr
     assert WARNING_FRAGMENT in result.stderr
-    # The actionable payload must survive any future copy-edits to the warning.
     assert 'first line of your entry point' in result.stderr
     assert 'https://github.com/zauberzeug/nicegui/issues/6024' in result.stderr
 
 
 @needs_httpxyz
-def test_real_httpx_with_late_httpxyz_warns() -> None:
-    """When real httpx wins the slot before httpxyz is imported, we warn (alias was a no-op)."""
+def test_real_httpx_with_late_httpxyz_warns():
     result = _run('''
-        import httpx  # noqa: F401
-        import httpxyz  # noqa: F401
-        import nicegui  # noqa: F401
+        import httpx
+        import httpxyz
+        import nicegui
     ''')
     assert result.returncode == 0, result.stderr
     assert WARNING_FRAGMENT in result.stderr
 
 
-def test_warning_points_at_user_code_not_nicegui() -> None:
-    """``stacklevel`` must point at the caller's ``import nicegui``, not at ``nicegui/__init__.py``."""
+def test_warning_points_at_user_code_not_nicegui():
     result = _run('''
         import warnings
         warnings.simplefilter("always")
-        import httpx  # noqa: F401
+        import httpx
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            import nicegui  # noqa: F401
+            import nicegui
         for w in caught:
             if "Real httpx is loaded" in str(w.message):
-                # filename should be the -c script (\"<string>\"), not somewhere inside the nicegui package
                 assert "nicegui" not in w.filename, f"warning points inside the package: {w.filename}"
                 print("STACKLEVEL_OK", w.filename)
                 break
         else:
-            raise AssertionError("expected httpxyz warning was not captured")
+            raise AssertionError("expected warning was not captured")
     ''')
     assert result.returncode == 0, result.stderr
     assert 'STACKLEVEL_OK' in result.stdout

--- a/tests/test_httpxyz_forward_compat.py
+++ b/tests/test_httpxyz_forward_compat.py
@@ -32,6 +32,19 @@ def test_warning_fires_iff_real_httpx_loaded(setup, expect_warning):
         assert WARNING_FRAGMENT not in result.stderr
 
 
+@needs_httpxyz
+def test_cold_auto_aliases_httpxyz_when_available():
+    result = _run('''
+        import nicegui
+        import httpx
+        import httpxyz
+        assert httpx is httpxyz, f"expected `import httpx` -> httpxyz, got {httpx}"
+        print("AUTO_ALIAS_OK")
+    ''')
+    assert result.returncode == 0, result.stderr
+    assert 'AUTO_ALIAS_OK' in result.stdout
+
+
 def test_warning_points_at_user_code_not_nicegui():
     result = _run('''
         import warnings

--- a/tests/test_httpxyz_forward_compat.py
+++ b/tests/test_httpxyz_forward_compat.py
@@ -13,7 +13,7 @@ import textwrap
 
 import pytest
 
-WARNING_FRAGMENT = 'httpxyz is loaded but real httpx was imported first'
+WARNING_FRAGMENT = 'Real httpx is loaded in this process'
 
 httpxyz_available = importlib.util.find_spec('httpxyz') is not None
 needs_httpxyz = pytest.mark.skipif(not httpxyz_available, reason='httpxyz not installed')
@@ -29,8 +29,8 @@ def _run(code: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_no_httpxyz_no_warning() -> None:
-    """When httpxyz is not imported, NiceGUI must stay silent."""
+def test_cold_import_nicegui_no_warning() -> None:
+    """A bare ``import nicegui`` with no prior httpx/httpxyz must stay silent."""
     result = _run('import nicegui  # noqa: F401')
     assert result.returncode == 0, result.stderr
     assert WARNING_FRAGMENT not in result.stderr
@@ -47,12 +47,10 @@ def test_httpxyz_first_no_warning() -> None:
     assert WARNING_FRAGMENT not in result.stderr
 
 
-@needs_httpxyz
-def test_real_httpx_first_warns() -> None:
-    """When real httpx is imported before httpxyz, the alias fails and we warn."""
+def test_real_httpx_loaded_warns_without_httpxyz() -> None:
+    """When real httpx is loaded but httpxyz is not, we still warn — that user is the migration target."""
     result = _run('''
         import httpx  # noqa: F401
-        import httpxyz  # noqa: F401
         import nicegui  # noqa: F401
     ''')
     assert result.returncode == 0, result.stderr
@@ -63,18 +61,28 @@ def test_real_httpx_first_warns() -> None:
 
 
 @needs_httpxyz
+def test_real_httpx_with_late_httpxyz_warns() -> None:
+    """When real httpx wins the slot before httpxyz is imported, we warn (alias was a no-op)."""
+    result = _run('''
+        import httpx  # noqa: F401
+        import httpxyz  # noqa: F401
+        import nicegui  # noqa: F401
+    ''')
+    assert result.returncode == 0, result.stderr
+    assert WARNING_FRAGMENT in result.stderr
+
+
 def test_warning_points_at_user_code_not_nicegui() -> None:
     """``stacklevel`` must point at the caller's ``import nicegui``, not at ``nicegui/__init__.py``."""
     result = _run('''
         import warnings
         warnings.simplefilter("always")
         import httpx  # noqa: F401
-        import httpxyz  # noqa: F401
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             import nicegui  # noqa: F401
         for w in caught:
-            if "httpxyz" in str(w.message):
+            if "Real httpx is loaded" in str(w.message):
                 # filename should be the -c script (\"<string>\"), not somewhere inside the nicegui package
                 assert "nicegui" not in w.filename, f"warning points inside the package: {w.filename}"
                 print("STACKLEVEL_OK", w.filename)


### PR DESCRIPTION
### Motivation

Grace-period complement to the planned 4.0 migration to httpxyz ([#6024](https://github.com/zauberzeug/nicegui/issues/6024)).

httpxyz registers itself as `httpx` in `sys.modules` via `setdefault`, so `import httpx` resolves to httpxyz when httpxyz is imported first. NiceGUI 4.0 will require httpxyz exclusively. The full migration story:

- **3.x:** NiceGUI stays neutral. Internals continue to use `import httpx`, picking up whichever module owns the slot. Users who want forward-compat add `import httpxyz` as the first line of their entry point — that one line aliases httpx -> httpxyz process-wide for *all* libraries (NiceGUI, anthropic, openai, etc.), not just NiceGUI.
- **4.0** ([Falko's plan in #6024](https://github.com/zauberzeug/nicegui/issues/6024)): NiceGUI internals switch to `import httpxyz` natively, drop httpx from deps, re-type public API. Hard cut.

This PR adds a runtime nudge in 3.x for the population the warning is actually meant to help: anyone who has real httpx loaded in their process at NiceGUI import time.

### Implementation

- `nicegui/_httpxyz_compat.py` (new): runs once on import. If `sys.modules['httpx']` is loaded and is *not* the same object as `sys.modules.get('httpxyz')`, emit a `UserWarning` pointing at the one-line fix and at #6024. Inlined at module top-level so `stacklevel=3` correctly points at the user's `import nicegui`, not at NiceGUI internals.
- `nicegui/__init__.py`: imports `_httpxyz_compat` first, on its own line above the existing tuple import, with a comment explaining the ordering invariant. `# noqa: F401, I001` keeps the linter happy without merging into the tuple (which would make the ordering-runs-first invariant accidental rather than intentional).
- `tests/test_httpxyz_forward_compat.py` (new): five subprocess-isolated scenarios — cold (silent), httpxyz-first (silent), real-httpx-only (warns; the no-httpxyz-yet population), real-httpx-then-httpxyz (warns; alias failed), and a stacklevel test asserting the warning's `filename` is *not* inside the `nicegui/` package. Tests skip cleanly when httpxyz is not installed.

### Why this gate

The fire condition is `'httpx' in sys.modules and sys.modules['httpx'] is not sys.modules.get('httpxyz')`. Truth table:

| State at NiceGUI import | Should fire? | Fires? |
|---|---|---|
| Cold `import nicegui` (no httpx, no httpxyz) | No | No |
| `import httpxyz` first (alias caught) | No | No |
| `import httpx` only (no httpxyz at all) — **migration target** | Yes | Yes |
| `import httpx` then `import httpxyz` (alias failed) | Yes | Yes |
| `import anthropic` (transitively loads real httpx) | Yes | Yes |

A narrower gate (`_httpxyz is not None and ...`) would silently pass the third and fifth rows — exactly the populations who most need to hear about 4.0. In-process `'httpx' in sys.modules` is narrower than the rejected `importlib.metadata.distribution('httpx')` probe: it only fires when something in this process actually loaded real httpx, so cold users stay silent.

### What this PR explicitly does *not* do

We considered and rejected several more-aggressive detection mechanisms:

- **Probing `importlib.metadata.distribution('httpx')`** to flag "httpx exists on disk anywhere" — too noisy for non-venv users for whom httpx is a transitive dep of unrelated libraries.
- **Installing a `sys.meta_path` finder** to catch late `import httpx` (in functions, transitively) — would catch the in-function newbie pattern, but means a UI library mutates the global import system, with false positives from any library that lazily imports httpx.
- **NiceGUI proactively `import httpxyz` at startup** — would auto-alias for users with httpxyz installed, but adds the kind of import-time magic Falko's "simplicity over cleverness" prefers to avoid. Saved for 4.0's native switch instead.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary. <!-- The warning text itself + #6024 link is the docs surface. Open question: does this also deserve a section in the migration / release notes? -->
- [x] No breaking changes to the public API.