### PR TITLE
Fix `RuntimeError` (SemLock fork/spawn) in `ui.run(native=True)` on Python ≥ 3.11.5

### DIFF
--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -2,14 +2,18 @@
 from __future__ import annotations
 
 import inspect
+import multiprocessing
 import warnings
 from collections.abc import Callable
-from multiprocessing import Pipe, Queue
+from multiprocessing import Queue
 from multiprocessing.connection import Connection
 from typing import Any
 
 from .. import run
 from ..logging import log
+
+# spawn context so primitives can be pickled into uvicorn's spawn-context ChangeReload worker (#1841)
+_SPAWN_CTX = multiprocessing.get_context('spawn')
 
 method_queue: Queue | None = None
 response_queue: Queue | None = None
@@ -20,9 +24,9 @@ event_sender: Connection | None = None
 def create_queues() -> None:
     """Create the message queues and event pipe. (For internal use only.)"""
     global method_queue, response_queue, event_receiver, event_sender  # pylint: disable=global-statement # noqa: PLW0603
-    method_queue = Queue()
-    response_queue = Queue()
-    event_receiver, event_sender = Pipe(duplex=False)
+    method_queue = _SPAWN_CTX.Queue()
+    response_queue = _SPAWN_CTX.Queue()
+    event_receiver, event_sender = _SPAWN_CTX.Pipe(duplex=False)
 
 
 def remove_queues() -> None:

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -244,7 +244,7 @@ def run(root: Callable | None = None, *,
         width, height = window_size or (800, 600)
         native_host = '127.0.0.1' if host == '0.0.0.0' else host
         if reload:
-            shutdown_event = multiprocessing.Event()
+            shutdown_event = multiprocessing.get_context('spawn').Event()  # match uvicorn ChangeReload worker (#1841)
         native_favicon = str(Path(favicon).resolve()) if favicon and helpers.is_file(favicon) else None
         native_module.activate(protocol, native_host, port, title, width, height, fullscreen, frameless,
                                shutdown_event, native_favicon)


### PR DESCRIPTION
### Motivation

Fixes [zauberzeug/nicegui#1841](https://github.com/zauberzeug/nicegui/issues/1841) (long-running `ui.run(native=True)` `RuntimeError: A SemLock created in a fork context is being shared with a process in a spawn context`).

Empirical evidence + reasoning is in [zauberzeug/nicegui#1841 (comment by Claude+evnchn 2026-05-09)](https://github.com/zauberzeug/nicegui/issues/1841#issuecomment-4408850083). One-line summary: NiceGUI's native-mode IPC primitives use the default multiprocessing context (fork on Linux through 3.13). uvicorn's `ChangeReload` supervisor uses an explicit spawn context for its worker, so when it pickles the parent's state across the fork→spawn boundary the SemLocks crash. CPython ≥ 3.11.5 raises this as `RuntimeError` ([gh-77377](https://github.com/python/cpython/issues/77377)); older versions silently corrupted state in the spawn child instead, which is what caused the long tail of mysterious "leaked semaphore" / "semaphore released too many times" reports in the same issue.

### Implementation

Switch NiceGUI's three Linux-native-mode IPC primitives to an explicit spawn context. Two callsites:

```diff
# nicegui/native/native.py
+import multiprocessing
-from multiprocessing import Pipe, Queue
+from multiprocessing import Queue

+# spawn context so primitives can be pickled into uvicorn's spawn-context ChangeReload worker (#1841)
+_SPAWN_CTX = multiprocessing.get_context('spawn')

 def create_queues() -> None:
-    method_queue = Queue()
-    response_queue = Queue()
-    event_receiver, event_sender = Pipe(duplex=False)
+    method_queue = _SPAWN_CTX.Queue()
+    response_queue = _SPAWN_CTX.Queue()
+    event_receiver, event_sender = _SPAWN_CTX.Pipe(duplex=False)
```

```diff
# nicegui/ui_run.py:247
-            shutdown_event = multiprocessing.Event()
+            shutdown_event = multiprocessing.get_context('spawn').Event()  # match uvicorn ChangeReload worker (#1841)
```

This is the pattern Python's docs explicitly recommend for libraries: ["Libraries using multiprocessing should be designed to allow their users to provide their own multiprocessing context"](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods), and CPython's own SemLock error message ends with *"Please use the same context to create multiprocessing objects and Process"*. Pywebview — NiceGUI's own dependency — already uses the same pattern in [`examples/pystray_icon.py`](https://github.com/r0x0r/pywebview/blob/master/examples/pystray_icon.py) for the equivalent macOS spawn case.

The alternative discussed in the issue (`multiprocessing.set_start_method('spawn', force=True)`) was rejected because it mutates the global default and breaks user code that relies on fork (CoW model loading, post-fork file descriptors, ML pipelines that fork from large parents). The patch here keeps the user's default untouched and only spawn-types NiceGUI's three IPC primitives.

### Verification

Reproduced unfixed bug + confirmed the patch removes it on `python:3.12-slim` Docker, with the patched repo mounted via `PYTHONPATH` (no monkey-patching):

```
=== unpatched (control on Python 3.12.13) ===
VERDICT: SEMLOCK_FIRED      ← bug exists

=== patched ===
location: /nicegui-src/nicegui/__init__.py    ← my patched repo
_SPAWN_CTX present: True
VERDICT: RAN_AND_RETURNED   ← bug gone
NiceGUI ready to go on http://127.0.0.1:8000

=== user fork-context preserved (no global side effect) ===
default start method after import: None              ← unchanged
mp.get_context('fork').Queue() still works: Queue    ← user code OK
```

CPython 3.11.5 boundary (where the bug starts manifesting) and the full distro × backend × Python sweep are documented in the issue comment linked above.

`uv run pylint nicegui/native/native.py nicegui/ui_run.py` → 10.00/10.
`uv run mypy nicegui/native/native.py nicegui/ui_run.py` → no issues.
`uv run pre-commit run --files nicegui/native/native.py nicegui/ui_run.py` → all checks pass.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [ ] Pytests have been added/updated or are not necessary. <!-- Reviewer call: NiceGUI's pytest harness doesn't run native mode (`is_pytest()` short-circuits in `ui_run.py`), and the bug is in the cross-process pickle path which is hard to assert in-process. The empirical Docker-based verification is in the Verification section above. Happy to add a regression test if you have a preferred shape — e.g. an `AssertionError` if `nicegui.native.native._SPAWN_CTX.get_start_method() != 'spawn'`. -->
- [x] Documentation has been added/updated or is not necessary. <!-- Internal change; user-facing behavior on the success path is unchanged. -->
- [x] No breaking changes to the public API or migration steps are described above.

---

*Drafted by Claude Code working with @evnchn — empirical investigation across distros and CPython patch versions, then surgical fix matching pywebview's existing pattern. Routed to fork first per `feedback_falko_bandwidth.md` for review before upstream.*
