### PR TITLE
Add /sitemap.xml endpoint with opt-in @ui.page integration

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -18,6 +18,7 @@ from ..logging import log
 from ..native import NativeConfig
 from ..observables import ObservableSet
 from ..server import Server
+from ..sitemap import Sitemap
 from ..staticfiles import CacheControlledStaticFiles
 from ..storage import Storage
 from .app_config import AppConfig
@@ -38,6 +39,7 @@ class App(FastAPI):
         super().__init__(**kwargs, docs_url=None, redoc_url=None, openapi_url=None)
         self.native = NativeConfig()
         self.storage = Storage()
+        self.sitemap = Sitemap()
         self.urls = ObservableSet()
         self._state: State = State.STOPPED
         self.config = AppConfig()
@@ -368,6 +370,7 @@ class App(FastAPI):
     def reset(self) -> None:
         """Reset app to its initial state. (Useful for testing.)"""
         self.storage.clear()
+        self.sitemap.reset()
         self._startup_handlers.clear()
         self._shutdown_handlers.clear()
         self._connect_handlers.clear()

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -66,6 +66,16 @@ static_files = CacheControlledStaticFiles(
 app.mount(f'/_nicegui/{__version__}/static', static_files, name='static')
 
 
+@app.get('/sitemap.xml', include_in_schema=False)
+def _get_sitemap(request: Request) -> Response:
+    if app.sitemap.base_url is not None:
+        base_url = app.sitemap.base_url
+    else:
+        prefix = request.headers.get('X-Forwarded-Prefix', '') + request.scope.get('root_path', '')
+        base_url = f'{request.url.scheme}://{request.url.netloc}{prefix}'
+    return Response(content=app.sitemap.to_xml(base_url), media_type='application/xml')
+
+
 @app.get(f'/_nicegui/{__version__}' + '/libraries/{key:path}')
 def _get_library(key: str) -> FileResponse:
     is_map = key.endswith('.map')

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -32,6 +32,7 @@ class page:
                  response_timeout: float = 3.0,
                  reconnect_timeout: float | None = None,
                  markdown: bool | None = None,
+                 sitemap: bool | dict = False,
                  api_router: APIRouter | None = None,
                  **kwargs: Any,
                  ) -> None:
@@ -60,6 +61,11 @@ class page:
         :param reconnect_timeout: maximum time the server waits for the browser to reconnect (defaults to `reconnect_timeout` argument of `run` command))
         :param markdown: whether to serve a Markdown representation when a client sends ``Accept: text/markdown``
             (experimental, defaults to `markdown` argument of `run` command, *added in version 3.11.0*)
+        :param sitemap: whether the page should appear in ``/sitemap.xml``. Default: ``False``
+            (NiceGUI does not enumerate page paths anywhere public by default, so opt-in preserves
+            apps relying on unguessable URLs). Pass ``True`` to include with no metadata, or a dict like
+            ``{'lastmod': '2026-05-14', 'changefreq': 'weekly', 'priority': 0.8}`` to attach metadata.
+            Paths with ``{...}`` parameters are always skipped (no enumerator).
         :param api_router: APIRouter instance to use, can be left `None` to use the default
         :param kwargs: additional keyword arguments passed to FastAPI's @app.get method
         """
@@ -74,6 +80,13 @@ class page:
         self.api_router = api_router or core.app.router
         self.reconnect_timeout = reconnect_timeout
         self.markdown = markdown
+
+        if sitemap is False:
+            core.app.sitemap.remove(self.path)
+        elif sitemap is True:
+            core.app.sitemap.add(self.path)
+        else:
+            core.app.sitemap.add(self.path, **sitemap)
 
         create_favicon_route(self.path, favicon)
 

--- a/nicegui/sitemap.py
+++ b/nicegui/sitemap.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+_NS = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+
+
+@dataclass
+class SitemapEntry:
+    path: str
+    lastmod: str | None = None
+    changefreq: str | None = None
+    priority: float | None = None
+
+
+_VALID_FIELDS = ('lastmod', 'changefreq', 'priority')
+
+
+class Sitemap:
+    """Registry of URLs served at ``/sitemap.xml``.
+
+    Pages are **opt-in**: NiceGUI does not enumerate ``@ui.page`` routes anywhere
+    public by default, so an app may rely on unguessable URLs (e.g.
+    ``/super-secret-page-only-i-know``) as a soft auth signal. Auto-publishing
+    those into a sitemap would silently break that pattern.
+
+    Opt in per-page with ``@ui.page('/path', sitemap=True)`` or
+    ``@ui.page('/path', sitemap={'changefreq': 'daily', 'priority': 0.9})``.
+    For URLs that don't map one-to-one to an ``@ui.page`` decoration —
+    ``ui.sub_pages`` routes (per-request, not knowable at startup), parameterized
+    ``@ui.page('/foo/{name}')`` routes (no enumerator), or hand-curated entries —
+    iterate over your own index and call ``app.sitemap.add('/path', ...)``::
+
+        @ui.page('/documentation/{path:path}')
+        def docs_page(): ...
+
+        for name in documentation_registry:
+            app.sitemap.add(f'/documentation/{name}', changefreq='weekly')
+
+    Set ``app.sitemap.base_url = 'https://example.com'`` to pin the canonical
+    URL. If unset, the URL is derived from the incoming request (correct in dev
+    and behind any reverse proxy configured to populate uvicorn's proxy headers).
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, SitemapEntry] = {}
+        self.base_url: str | None = None
+
+    def add(self,
+            path: str,
+            *,
+            lastmod: str | None = None,
+            changefreq: str | None = None,
+            priority: float | None = None,
+            **unknown: Any,
+            ) -> None:
+        """Include ``path`` in the sitemap, replacing any prior entry for the same path.
+
+        :param path: concrete route path starting with ``/`` (e.g. ``/docs/intro``).
+            Parameterized paths (containing ``{...}``) are rejected — add one entry per concrete URL instead.
+        :param lastmod: ISO-8601 date or datetime of last modification
+        :param changefreq: ``always``, ``hourly``, ``daily``, ``weekly``, ``monthly``, ``yearly``, or ``never``
+        :param priority: relative importance from ``0.0`` to ``1.0``
+        """
+        if '{' in path:
+            raise ValueError(
+                f'Cannot add parameterized path {path!r} to the sitemap: there is no enumerator. '
+                "Add a concrete path per URL instead (e.g. app.sitemap.add('/users/alice'))."
+            )
+        if unknown:
+            raise ValueError(
+                f'Unknown sitemap field(s) for {path!r}: {sorted(unknown)}. '
+                f'Supported: {list(_VALID_FIELDS)}. See https://www.sitemaps.org/protocol.html'
+            )
+        self._entries[path] = SitemapEntry(path, lastmod, changefreq, priority)
+
+    def remove(self, path: str) -> None:
+        """Retract a previously added entry. No-op if ``path`` is not present."""
+        self._entries.pop(path, None)
+
+    def reset(self) -> None:
+        """Clear all entries and the base URL. (For testing.)"""
+        self._entries.clear()
+        self.base_url = None
+
+    def entries(self) -> Iterator[SitemapEntry]:
+        """Yield every entry that should appear in the sitemap."""
+        yield from self._entries.values()
+
+    def to_xml(self, base_url: str) -> str:
+        """Render the sitemap as XML rooted at ``base_url`` (e.g. ``https://example.com``)."""
+        ET.register_namespace('', _NS)
+        urlset = ET.Element(f'{{{_NS}}}urlset')
+        for entry in self.entries():
+            url = ET.SubElement(urlset, f'{{{_NS}}}url')
+            ET.SubElement(url, f'{{{_NS}}}loc').text = base_url.rstrip('/') + entry.path
+            if entry.lastmod is not None:
+                ET.SubElement(url, f'{{{_NS}}}lastmod').text = entry.lastmod
+            if entry.changefreq is not None:
+                ET.SubElement(url, f'{{{_NS}}}changefreq').text = entry.changefreq
+            if entry.priority is not None:
+                ET.SubElement(url, f'{{{_NS}}}priority').text = f'{entry.priority:.1f}'
+        return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(urlset, encoding='unicode')

--- a/nicegui/testing/general.py
+++ b/nicegui/testing/general.py
@@ -33,7 +33,8 @@ def prepare_simulation() -> None:
 def nicegui_reset_globals():
     """Reset the global state of the NiceGUI package."""
     for route in list(app.routes):
-        if isinstance(route, Route) and (
+        # NOTE: /sitemap.xml is registered at module import time and not re-created per test; preserve it
+        if isinstance(route, Route) and route.path != '/sitemap.xml' and (
             not route.path.startswith('/_nicegui/')
             or route.path.startswith('/_nicegui/auto/static')
             or route.path.startswith('/_nicegui/client/')

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,0 +1,184 @@
+import xml.etree.ElementTree as ET
+
+import pytest
+from fastapi.testclient import TestClient
+
+from nicegui import app, core, ui
+from nicegui.sitemap import Sitemap
+
+NS = '{http://www.sitemaps.org/schemas/sitemap/0.9}'
+
+
+# -------------------------------------------------------------------- Sitemap class (pure unit)
+
+
+def test_sitemap_is_empty_by_default():
+    assert list(Sitemap().entries()) == []
+
+
+def test_add_then_remove_round_trips():
+    s = Sitemap()
+    s.add('/a')
+    s.add('/b', changefreq='daily', priority=0.5)
+    assert {e.path for e in s.entries()} == {'/a', '/b'}
+    s.remove('/a')
+    assert {e.path for e in s.entries()} == {'/b'}
+    s.remove('/missing')  # no-op
+
+
+def test_add_replaces_metadata_for_same_path():
+    s = Sitemap()
+    s.add('/a', priority=0.1)
+    s.add('/a', priority=0.9)
+    entry = next(s.entries())
+    assert entry.priority == 0.9
+
+
+def test_add_rejects_parameterized_paths():
+    s = Sitemap()
+    with pytest.raises(ValueError, match=r"Cannot add parameterized path '/user/\{user_id\}'"):
+        s.add('/user/{user_id}')
+
+
+def test_to_xml_uses_sitemap_namespace_and_metadata():
+    s = Sitemap()
+    s.add('/a', lastmod='2026-05-14', changefreq='weekly', priority=0.8)
+    root = ET.fromstring(s.to_xml('https://example.com'))
+    assert root.tag == f'{NS}urlset'
+    url = root.find(f'{NS}url')
+    assert url is not None
+    assert url.findtext(f'{NS}loc') == 'https://example.com/a'
+    assert url.findtext(f'{NS}lastmod') == '2026-05-14'
+    assert url.findtext(f'{NS}changefreq') == 'weekly'
+    assert url.findtext(f'{NS}priority') == '0.8'
+
+
+def test_to_xml_escapes_special_characters():
+    s = Sitemap()
+    s.add('/search?q=<x>&y=1')
+    root = ET.fromstring(s.to_xml('https://example.com'))
+    assert root.findtext(f'{NS}url/{NS}loc') == 'https://example.com/search?q=<x>&y=1'
+
+
+# ----------------------------------------------------- @ui.page decorator integration
+
+
+def test_default_does_not_register(nicegui_reset_globals):
+    @ui.page('/secret')
+    def _secret():
+        ui.label('secret')
+
+    assert list(app.sitemap.entries()) == []
+
+
+def test_sitemap_true_registers(nicegui_reset_globals):
+    @ui.page('/about', sitemap=True)
+    def _about():
+        ui.label('about')
+
+    assert {e.path for e in app.sitemap.entries()} == {'/about'}
+
+
+def test_sitemap_dict_registers_with_metadata(nicegui_reset_globals):
+    @ui.page('/', sitemap={'changefreq': 'daily', 'priority': 1.0})
+    def _home():
+        ui.label('home')
+
+    entry = next(app.sitemap.entries())
+    assert entry.path == '/'
+    assert entry.changefreq == 'daily'
+    assert entry.priority == 1.0
+
+
+def test_sitemap_false_after_true_retracts(nicegui_reset_globals):
+    @ui.page('/about', sitemap=True)
+    def _included():
+        ui.label('about')
+
+    @ui.page('/about', sitemap=False)
+    def _excluded():
+        ui.label('about')
+
+    assert list(app.sitemap.entries()) == []
+
+
+@pytest.mark.parametrize('opt_in', [True, {'changefreq': 'daily'}])
+def test_opting_a_parameterized_page_in_raises(opt_in, nicegui_reset_globals):
+    with pytest.raises(ValueError, match='Cannot add parameterized path'):
+        @ui.page('/user/{user_id}', sitemap=opt_in)
+        def _user(user_id: str):
+            ui.label(user_id)
+
+
+def test_unknown_sitemap_field_raises_on_decorator(nicegui_reset_globals):
+    with pytest.raises(ValueError, match=r"Unknown sitemap field\(s\) for '/about': \['typo'\]"):
+        @ui.page('/about', sitemap={'typo': 'oops'})
+        def _about():
+            ui.label('about')
+
+
+def test_unknown_sitemap_field_raises_on_direct_add():
+    s = Sitemap()
+    with pytest.raises(ValueError, match=r"Unknown sitemap field\(s\) for '/a': \['lastmode'\]"):
+        s.add('/a', lastmode='2026-05-14')  # typo of lastmod
+
+
+# ------------------------------------------------- /sitemap.xml endpoint (FastAPI TestClient)
+
+
+def _locations(text: str) -> set[str]:
+    root = ET.fromstring(text)
+    return {loc.text for loc in root.iter(f'{NS}loc') if loc.text is not None}
+
+
+def test_endpoint_serves_xml_with_absolute_urls(nicegui_reset_globals):
+    @ui.page('/', sitemap=True)
+    def _home():
+        ui.label('home')
+
+    response = TestClient(core.app).get('/sitemap.xml')
+    assert response.status_code == 200
+    assert response.headers['content-type'].startswith('application/xml')
+    locations = _locations(response.text)
+    assert locations
+    for loc in locations:
+        assert loc.startswith(('http://', 'https://'))
+
+
+def test_endpoint_honors_base_url_override(nicegui_reset_globals):
+    @ui.page('/', sitemap=True)
+    def _home():
+        ui.label('home')
+
+    app.sitemap.base_url = 'https://nicegui.io'
+    response = TestClient(core.app).get('/sitemap.xml')
+    assert all(loc.startswith('https://nicegui.io/') for loc in _locations(response.text))
+
+
+def test_endpoint_honors_forwarded_prefix(nicegui_reset_globals):
+    @ui.page('/', sitemap=True)
+    def _home():
+        ui.label('home')
+
+    response = TestClient(core.app).get('/sitemap.xml', headers={'X-Forwarded-Prefix': '/app'})
+    assert any('/app/' in loc for loc in _locations(response.text))
+
+
+def test_endpoint_reflects_documentation_pattern(nicegui_reset_globals):
+    """Mirror nicegui.io: stacked decorators (one parameterized) + manual adds for concrete docs URLs."""
+    @ui.page('/', sitemap=True)
+    @ui.page('/examples', sitemap=True)
+    @ui.page('/documentation', sitemap=True)
+    @ui.page('/documentation/{path:path}')  # parameterized → skipped
+    def _main():
+        ui.label('main')
+
+    for name in ['button', 'label']:
+        app.sitemap.add(f'/documentation/{name}', changefreq='weekly')
+
+    locations = _locations(TestClient(core.app).get('/sitemap.xml').text)
+    assert any(loc.endswith('/examples') for loc in locations)
+    assert any(loc.endswith('/documentation') for loc in locations)
+    assert any(loc.endswith('/documentation/button') for loc in locations)
+    assert any(loc.endswith('/documentation/label') for loc in locations)
+    assert not any('{' in loc for loc in locations)


### PR DESCRIPTION
*Drafted by Claude Code working with @evnchn.*

Tracking: evnchn/nicegui#151 (Layer 1 — sitemap groundwork). Sized to be Falko-friendly per the issue's "small focused PR" rule.

### Motivation

Sitemaps are the cheapest SEO win available — Google's docs explicitly favor them when site structure is non-trivial — but every NiceGUI app today has to hand-roll one. `https://nicegui.io/sitemap.xml` and every downstream sibling currently 404. This adds a framework-level endpoint without auto-publishing anything that wasn't already publicly known, so apps using long unguessable URLs as soft auth keep that invariant on upgrade.

### Implementation

#### Opt-in per page

```python
@ui.page('/', sitemap=True)
def home(): ...

@ui.page('/docs', sitemap={'changefreq': 'daily', 'priority': 0.9})
def docs(): ...
```

`sitemap: bool | dict = False`. Default `False` is load-bearing — NiceGUI does not enumerate `@ui.page` paths anywhere public today: `App(openapi_url=None)` (`app/app.py:39`), `endpoint_documentation='none'` default (`app_config.py:10`, `page.py:128`), `Client.page_routes` is internal-only (used only by `link.py`, `navigate.py`, `client.py:275`, startup logging in `ui_run.py`). Auto-publishing on upgrade would silently leak any page whose URL was the secret.

#### Hand-curated entries

For URLs that don't map one-to-one to a decoration — `ui.sub_pages` routes (per-request, not knowable at startup), parameterized `@ui.page('/docs/{name}')` routes (no enumerator), or anything else — iterate your own index and call `app.sitemap.add(...)`:

```python
@ui.page('/documentation/{path:path}')
def docs(): ...

for name in documentation_registry:
    app.sitemap.add(f'/documentation/{name}', changefreq='weekly')
```

#### Single validation point

`Sitemap.add()` rejects parameterized paths and unknown sitemap fields with `ValueError` and a message pointing at the correct escape hatch. Both `@ui.page(sitemap=...)` and direct `app.sitemap.add(...)` route through it, so there's exactly one DRY check site — no decorator-vs-direct-API skew, no silent filtering.

```
ValueError: Cannot add parameterized path '/users/{id}' to the sitemap: there is no enumerator.
            Add a concrete path per URL instead (e.g. app.sitemap.add('/users/alice')).

ValueError: Unknown sitemap field(s) for '/about': ['lastmode'].
            Supported: ['lastmod', 'changefreq', 'priority'].
            See https://www.sitemaps.org/protocol.html
```

#### Canonical URL

```python
app.sitemap.base_url = 'https://nicegui.io'   # production pin
```

If unset, the URL is derived from the request (correct in dev and behind any reverse proxy that populates uvicorn's standard headers — `proxy_headers=True` is uvicorn's default, so `request.url.scheme` and `request.url.netloc` already reflect `X-Forwarded-Proto`/`X-Forwarded-Host` at the ASGI layer; re-reading them in FastAPI would be redundant and create a spoofing surface on deployments without `forwarded_allow_ips` whitelisting). The endpoint additionally honors `X-Forwarded-Prefix` + ASGI `root_path` to match the existing NiceGUI convention (`client.py:172`, `middlewares.py:12`, `sub_pages_router.py:26`).

### Testing

18 tests in `tests/test_sitemap.py`, 0.27 s total, three browser-free tiers:

| Tier | Fixture | What it covers |
|------|---------|----------------|
| Unit | none — instantiate `Sitemap()` directly | `entries()`, `add()`/`remove()` round-trip, metadata override, `to_xml()` namespace + XML escaping, parameterized + unknown-field rejection |
| Decorator | `nicegui_reset_globals` (pure-Python reset) | `sitemap=False` default no-op, `sitemap=True`, `sitemap={dict}`, retract via re-decoration, `ValueError` on parameterized opt-in, `ValueError` on unknown fields |
| Endpoint | `nicegui_reset_globals` + `fastapi.testclient.TestClient(core.app)` (same pattern as `tests/test_run_with.py`) | XML+absolute URLs, `base_url` override, `X-Forwarded-Prefix`, nicegui.io documentation composition |

### Out of scope (deferred per #151)

- `/robots.txt` pointing at `Sitemap:`
- Per-page `<link rel="canonical">`
- Per-page `<meta description>` mechanism
- Sourcing `lastmod` from git or filesystem

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation has been added (docstrings on `Sitemap`, `Sitemap.add`, and `@ui.page`'s `sitemap` parameter).
- [x] No breaking changes to the public API.
