### PR TITLE
guard Element.run_method/update against deleted client vs deleted element (#6058)

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -16,7 +16,7 @@ from starlette.background import BackgroundTask
 from typing_extensions import Self
 
 from . import background_tasks, binding, core, helpers, json, storage
-from .awaitable_response import AwaitableResponse, NullResponse
+from .awaitable_response import AwaitableResponse
 from .dependencies import generate_resources
 from .element import Element
 from .favicon import get_favicon_url
@@ -262,8 +262,6 @@ class Client:
 
         :return: AwaitableResponse that can be awaited to get the result of the JavaScript code
         """
-        if self._deleted:
-            return NullResponse()
         request_id = str(uuid.uuid4())
         target_id = self._temporary_socket_id or self.id
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -16,7 +16,7 @@ from starlette.background import BackgroundTask
 from typing_extensions import Self
 
 from . import background_tasks, binding, core, helpers, json, storage
-from .awaitable_response import AwaitableResponse
+from .awaitable_response import AwaitableResponse, NullResponse
 from .dependencies import generate_resources
 from .element import Element
 from .favicon import get_favicon_url
@@ -132,6 +132,11 @@ class Client:
     def has_socket_connection(self) -> bool:
         """Whether the client is connected."""
         return self.tab_id is not None
+
+    @property
+    def is_deleted(self) -> bool:
+        """Whether the client has been deleted (e.g. by browser disconnect after ``reconnect_timeout``)."""
+        return self._deleted
 
     @property
     def head_html(self) -> str:
@@ -257,6 +262,8 @@ class Client:
 
         :return: AwaitableResponse that can be awaited to get the result of the JavaScript code
         """
+        if self._deleted:
+            return NullResponse()
         request_id = str(uuid.uuid4())
         target_id = self._temporary_socket_id or self.id
 

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -412,7 +412,12 @@ class Element(Visibility):
 
     def update(self) -> None:
         """Update the element on the client side."""
+        if self.client.is_deleted:
+            return  # silent: client teardown race (e.g. browser reload during async callback)
         if self.is_deleted:
+            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
+                              'This is most likely a bug in your application code.',
+                              stack_info=True)
             return
         self.client.outbox.enqueue_update(self)
 
@@ -428,6 +433,13 @@ class Element(Visibility):
         """
         if not core.is_loop_running():
             return NullResponse()
+        if self.client.is_deleted:
+            return NullResponse()  # silent: client teardown race
+        if self.is_deleted:
+            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
+                              'This is most likely a bug in your application code.',
+                              stack_info=True)
+            return NullResponse()
         return self.client.run_javascript(
             f'return runMethod({self.id}, {json.dumps(name)}, {json.dumps(args)})', timeout=timeout,
         )
@@ -441,6 +453,13 @@ class Element(Visibility):
         :param timeout: maximum time to wait for a response (default: 1 second)
         """
         if not core.is_loop_running():
+            return NullResponse()
+        if self.client.is_deleted:
+            return NullResponse()  # silent: client teardown race
+        if self.is_deleted:
+            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
+                              'This is most likely a bug in your application code.',
+                              stack_info=True)
             return NullResponse()
         return self.client.run_javascript(
             f'return getComputedProp({self.id}, {json.dumps(prop_name)})', timeout=timeout,

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -410,14 +410,26 @@ class Element(Visibility):
         args = events.GenericEventArguments(sender=self, client=self.client, args=msg['args'])
         events.handle_event(listener.handler, args)
 
-    def update(self) -> None:
-        """Update the element on the client side."""
+    def _is_safe_to_interact(self) -> bool:
+        """Return True if it is safe to send messages to this element's client.
+
+        Silent when the *client* has been deleted (e.g. browser reload race past ``reconnect_timeout``):
+        an async callback resuming after the teardown is not a user bug. Emits a one-shot warning
+        when the *element* has been explicitly deleted but the client is still alive: that is a real
+        use-after-free in user code and worth surfacing.
+        """
         if self.client.is_deleted:
-            return  # silent: client teardown race (e.g. browser reload during async callback)
+            return False
         if self.is_deleted:
-            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
+            helpers.warn_once(f'{self} (id={self.id}) has been deleted but is still being used. '
                               'This is most likely a bug in your application code.',
                               stack_info=True)
+            return False
+        return True
+
+    def update(self) -> None:
+        """Update the element on the client side."""
+        if not self._is_safe_to_interact():
             return
         self.client.outbox.enqueue_update(self)
 
@@ -431,14 +443,7 @@ class Element(Visibility):
         :param args: arguments to pass to the method
         :param timeout: maximum time to wait for a response (default: 1 second)
         """
-        if not core.is_loop_running():
-            return NullResponse()
-        if self.client.is_deleted:
-            return NullResponse()  # silent: client teardown race
-        if self.is_deleted:
-            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
-                              'This is most likely a bug in your application code.',
-                              stack_info=True)
+        if not core.is_loop_running() or not self._is_safe_to_interact():
             return NullResponse()
         return self.client.run_javascript(
             f'return runMethod({self.id}, {json.dumps(name)}, {json.dumps(args)})', timeout=timeout,
@@ -452,14 +457,7 @@ class Element(Visibility):
         :param prop_name: name of the computed prop
         :param timeout: maximum time to wait for a response (default: 1 second)
         """
-        if not core.is_loop_running():
-            return NullResponse()
-        if self.client.is_deleted:
-            return NullResponse()  # silent: client teardown race
-        if self.is_deleted:
-            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
-                              'This is most likely a bug in your application code.',
-                              stack_info=True)
+        if not core.is_loop_running() or not self._is_safe_to_interact():
             return NullResponse()
         return self.client.run_javascript(
             f'return getComputedProp({self.id}, {json.dumps(prop_name)})', timeout=timeout,

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,7 +1,11 @@
+import logging
 import weakref
 
+import pytest
+
 from nicegui import binding, ui
-from nicegui.testing import Screen
+from nicegui.helpers import warnings as _warnings
+from nicegui.testing import Screen, User
 
 
 def test_remove_element_by_reference(screen: Screen):
@@ -194,6 +198,58 @@ def test_slot_children_cleared_on_delete(screen: Screen):
     screen.click('Delete')
     screen.should_contain('Deleted')
     assert len(labels) == 0, 'all labels should be deleted immediately'
+
+
+async def test_run_method_silent_after_client_delete(user: User, caplog: pytest.LogCaptureFixture):
+    """Mutations on elements after the client has been deleted (e.g. browser reload race
+    past reconnect_timeout) must be silent — user code did nothing wrong. See issue #6058."""
+    captured: dict = {}
+
+    @ui.page('/')
+    def page():
+        captured['label'] = ui.label('hi')
+
+    await user.open('/')
+    label = captured['label']
+    label.client.delete()
+    assert label.client.is_deleted
+    assert label.is_deleted  # cascaded
+
+    _warnings._shown_warnings.clear()  # pylint: disable=protected-access
+    caplog.clear()
+    caplog.set_level(logging.WARNING, logger='nicegui')
+    label.run_method('foo')
+    label.update()
+    label.get_computed_prop('bar')
+
+    warning_records = [r for r in caplog.records if 'deleted' in r.message.lower()]
+    assert warning_records == [], f'expected silent, got: {[r.message for r in warning_records]}'
+
+
+async def test_run_method_warns_after_explicit_element_delete(user: User, caplog: pytest.LogCaptureFixture):
+    """Calling a method on an explicitly deleted element while the client is still alive
+    is a user bug and should produce a visible (one-shot) warning. See issue #6058."""
+    captured: dict = {}
+
+    @ui.page('/')
+    def page():
+        with ui.row() as row:
+            captured['label'] = ui.label('hi')
+            captured['row'] = row
+
+    await user.open('/')
+    label = captured['label']
+    captured['row'].remove(label)
+    assert label.is_deleted
+    assert not label.client.is_deleted
+
+    _warnings._shown_warnings.clear()  # pylint: disable=protected-access
+    caplog.clear()
+    caplog.set_level(logging.WARNING, logger='nicegui')
+    label.run_method('foo')
+
+    warning_records = [r for r in caplog.records if 'still being used' in r.message]
+    assert warning_records, f'expected warning, got: {[r.message for r in caplog.records]}'
 
 
 def test_event_listeners_cleared_on_delete(screen: Screen):

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,10 +1,9 @@
-import logging
 import weakref
 
 import pytest
 
 from nicegui import binding, ui
-from nicegui.helpers import warnings as _warnings
+from nicegui.helpers.warnings import _shown_warnings
 from nicegui.testing import Screen, User
 
 
@@ -215,9 +214,8 @@ async def test_run_method_silent_after_client_delete(user: User, caplog: pytest.
     assert label.client.is_deleted
     assert label.is_deleted  # cascaded
 
-    _warnings._shown_warnings.clear()  # pylint: disable=protected-access
+    _shown_warnings.clear()
     caplog.clear()
-    caplog.set_level(logging.WARNING, logger='nicegui')
     label.run_method('foo')
     label.update()
     label.get_computed_prop('bar')
@@ -243,9 +241,8 @@ async def test_run_method_warns_after_explicit_element_delete(user: User, caplog
     assert label.is_deleted
     assert not label.client.is_deleted
 
-    _warnings._shown_warnings.clear()  # pylint: disable=protected-access
+    _shown_warnings.clear()
     caplog.clear()
-    caplog.set_level(logging.WARNING, logger='nicegui')
     label.run_method('foo')
 
     warning_records = [r for r in caplog.records if 'still being used' in r.message]


### PR DESCRIPTION
## Motivation

Upstream issue: [zauberzeug/nicegui#6058](https://github.com/zauberzeug/nicegui/issues/6058) — scene object mutations after \`await\` spam \`Client has been deleted but is still being used.\` warnings on reload, even though user code does nothing wrong.

Root cause is an asymmetry: \`Element.update()\` short-circuits on \`is_deleted\`, but \`Element.run_method()\` (which scene objects use to mutate) does not. The reporter proposed mirroring the existing guard. That works, but it would *also* silence the case where user code explicitly calls \`element.delete()\` and then accidentally uses the element again — a real bug that deserves a warning.

## Implementation

Two-tier deletion guard distinguishes the two cases via a new public \`Client.is_deleted\` property:

- **Client deleted** (e.g. browser reload race past \`reconnect_timeout\`) → **silent**. User code did nothing wrong.
- **Element deleted but client alive** (explicit \`element.delete()\` followed by misuse) → **one-shot warning with stack trace**. Footgun signal preserved.

Applied to \`Element.update()\`, \`Element.run_method()\`, and \`Element.get_computed_prop()\`. A simpler single-tier silent guard is added to \`Client.run_javascript()\` (no element context to discriminate).

## Progress

- [x] \`Client.is_deleted\` public property added
- [x] Two-tier guard in \`Element.update\` / \`run_method\` / \`get_computed_prop\`
- [x] Single-tier guard in \`Client.run_javascript\`
- [x] New test: \`test_run_method_silent_after_client_delete\` — confirms silent on disconnect race
- [x] New test: \`test_run_method_warns_after_explicit_element_delete\` — confirms warning preserved
- [x] All 31 existing tests in \`test_element_delete.py\` + \`test_keep_alive.py\` + \`test_scene.py\` still pass

## Prototype status

This is a rapid prototype on the fork. Open questions before upstreaming:
- Should \`Client.run_javascript\` (direct call) also produce a warning when called on a deleted client (e.g. for unscoped diagnostic value)? Currently silent.
- The reporter framed this as "missing guard"; the deeper issue is "ambiguous lifecycle state during \`reconnect_timeout\`." A two-phase \`detached → deleted\` lifecycle would collapse the race by construction. Could be a follow-up.