### PR TITLE
Add Plotly.extendTraces demo and run_plot_method helper

### DIFF
--- a/nicegui/elements/plotly/plotly.js
+++ b/nicegui/elements/plotly/plotly.js
@@ -1,3 +1,5 @@
+import { convertDynamicProperties } from "../../static/utils/dynamic_properties.js";
+
 export default {
   template: "<div></div>",
   async mounted() {
@@ -37,6 +39,14 @@ export default {
 
       // store last options
       this.last_options = options;
+    },
+    run_plot_method(name, ...args) {
+      if (typeof this.Plotly === "undefined") {
+        logAndEmit("error", "Plotly is not loaded yet.");
+        return;
+      }
+      convertDynamicProperties(args, true);
+      return runMethod(this.Plotly, name, [this.$el, ...args]);
     },
     set_handlers() {
       // forward events

--- a/nicegui/elements/plotly/plotly.py
+++ b/nicegui/elements/plotly/plotly.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import suppress
 
 from ... import optional_features
+from ...awaitable_response import AwaitableResponse
 from ...element import Element
 
 with suppress(ImportError):
@@ -38,6 +39,23 @@ class Plotly(Element, component='plotly.js', esm={'nicegui-plotly': 'dist'}):
         """Overrides figure instance of this Plotly chart and updates chart on client side."""
         self.figure = figure
         self.update()
+
+    def run_plot_method(self, name: str, *args, timeout: float = 1) -> AwaitableResponse:
+        """Run a plotly.js library function against the chart's HTML element.
+
+        See the `plotly.js function reference <https://plotly.com/javascript/plotlyjs-function-reference/>`_ for a list of methods.
+        The chart's HTML element is passed as the first argument automatically.
+
+        If the function is awaited, the result of the method call is returned.
+        Otherwise, the method is executed without waiting for a response.
+
+        :param name: name of the plotly.js function (without the ``Plotly.`` prefix)
+        :param args: arguments to pass after the chart element
+        :param timeout: timeout in seconds (default: 1 second)
+
+        :return: AwaitableResponse that can be awaited to get the result of the method call
+        """
+        return self.run_method('run_plot_method', name, *args, timeout=timeout)
 
     def update(self) -> None:
         with self._props.suspend_updates():

--- a/website/documentation/content/plotly_documentation.py
+++ b/website/documentation/content/plotly_documentation.py
@@ -67,6 +67,28 @@ def plot_updates():
     ui.button('Add trace', on_click=add_trace)
 
 
+@doc.demo('Extending traces without re-sending the full figure', '''
+    Calling `plot.update()` re-transmits the entire figure to the client.
+    For live data, [`Plotly.extendTraces`](https://plotly.com/javascript/plotlyjs-function-reference/#plotlyextendtraces) appends points to existing traces with minimal traffic.
+    Use `plot.run_plot_method('extendTraces', ...)` to call it directly, and mutate `figure['data']` on the server so the next `plot.update()` reflects the full state.
+''')
+def extending_traces():
+    from random import random
+
+    fig = {'data': [{'type': 'scatter', 'x': [], 'y': []}],
+           'layout': {'margin': {'l': 30, 'r': 0, 't': 0, 'b': 30}}}
+    plot = ui.plotly(fig).classes('w-full h-40')
+
+    def add_point():
+        t = len(fig['data'][0]['x'])
+        y = random()
+        fig['data'][0]['x'].append(t)
+        fig['data'][0]['y'].append(y)
+        plot.run_plot_method('extendTraces', {'x': [[t]], 'y': [[y]]}, [0])
+
+    ui.button('Add point', on_click=add_point)
+
+
 @doc.demo('Plot events', r'''
     This demo shows how to handle Plotly events.
     Try clicking on a data point to see the event data.


### PR DESCRIPTION
### Motivation

Mirrors [PR zauberzeug/nicegui#5967](https://github.com/zauberzeug/nicegui/pull/5967) (the AG Grid equivalent) for the Plotly side of the same problem: calling `plot.update()` re-transmits the entire figure to the client every time, which is wasteful for live data. Plotly.js has [`Plotly.extendTraces`](https://plotly.com/javascript/plotlyjs-function-reference/#plotlyextendtraces) for appending points to existing traces, but today reaching it requires `ui.run_javascript(...)` with a hand-built `getHtmlElement({plot.id})` lookup — discussed at length in [zauberzeug/nicegui#2660](https://github.com/zauberzeug/nicegui/discussions/2660).

This closes the design question @falkoschindler raised there with the lighter answer: don't add `extend_traces()` as a Python wrapper method (would commit NiceGUI to mirroring plotly.js's mutation vocabulary forever — the same slippery-slope concern that came up against the AG Grid version in #5952). Just make the existing primitive (`run_method` + `suspend_updates`) work directly and discoverable. See the [follow-up comment in #2660](https://github.com/zauberzeug/nicegui/discussions/2660#discussioncomment-16984084) for the longer reasoning.

### Implementation

Three small changes:

1. **`nicegui/elements/plotly/plotly.py`** — adds `run_plot_method(name, *args, timeout=1)`, signature mirrors `AgGrid.run_grid_method`. The chart's HTML element is passed as the first argument to the plotly.js function automatically, so users call `plot.run_plot_method('extendTraces', update, [0])` instead of building the DOM-lookup JS string.
2. **`nicegui/elements/plotly/plotly.js`** — adds the matching Vue method that dispatches to `this.Plotly[name](this.$el, ...args)` via the existing `runMethod` helper (gets the standard "method not found" error path for free).
3. **`website/documentation/content/plotly_documentation.py`** — adds a `@doc.demo('Extending traces without re-sending the full figure', ...)` right after the existing *Plot updates* demo. Shows the `extendTraces` recipe with `props.suspend_updates()` to keep the server-side `figure['data']` in sync without firing a full rebuild.

The docstring on `run_plot_method` links to the [plotly.js function reference](https://plotly.com/javascript/plotlyjs-function-reference/), which is the discoverability bridge — that URL is currently nowhere in NiceGUI's Python-side docs.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
- [x] No breaking changes to the public API.