### PR TITLE
Fix native mode crash on Linux Python 3.14 (forkserver default)

### DIFF
--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -179,7 +179,7 @@ def activate(protocol: str, host: str, port: int, title: str, width: int, height
     event_manager.start()
     args = (protocol, host, port, title, width, height, fullscreen, frameless,
             native.method_queue, native.response_queue, native.event_sender, favicon)
-    process = mp.Process(target=_open_window, args=args, daemon=True)
+    process = native.SPAWN_CONTEXT.Process(target=_open_window, args=args, daemon=True)
     process.start()
 
     Thread(target=check_shutdown, daemon=True).start()


### PR DESCRIPTION
Spike for upstream issue [zauberzeug/nicegui#6062](https://github.com/zauberzeug/nicegui/issues/6062). Completes the spawn-context migration started in [#6045](https://github.com/zauberzeug/nicegui/pull/6045), which moved Queue/Pipe/Event to `SPAWN_CONTEXT` but left `mp.Process` on the default context.

Python 3.14 changed the Linux multiprocessing default from `fork` to `forkserver`. Forkserver re-imports the user's main module to bootstrap workers but does not use the `--multiprocessing-fork` argv trampoline, so `mp.freeze_support()` cannot short-circuit and `_check_not_importing_main()` raises:

```
RuntimeError: An attempt has been made to start a new process before
the current process has finished its bootstrapping phase.
```

Fix: one-line change to `native.SPAWN_CONTEXT.Process(...)`. Spawn's trampoline runs the target and exits before reaching `ui.run()` in the child, so `app.native.window_args` / `start_args` / `settings` set in the user script still propagate correctly (verified empirically on Linux 3.14.5 and macOS 3.14.4).