### PR TITLE
Fix Storage.path clobber at import time (#6061)

### DIFF
--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -10,7 +10,7 @@ from . import general
 
 # pylint: disable=redefined-outer-name
 
-Storage.path = None  # type: ignore[assignment]  # sentinel; pytest_configure assigns a session-unique tempdir
+_storage_configured = False  # separate sentinel so plain `import nicegui.testing` doesn't clobber Storage.path
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -20,8 +20,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 def pytest_configure(config: pytest.Config) -> None:
     """Set up a session-unique storage path and register the "nicegui_main_file" marker."""
-    if Storage.path is not None:
+    global _storage_configured  # pylint: disable=global-statement # noqa: PLW0603
+    if _storage_configured:
         return  # already configured (e.g. plugin.py + user_plugin.py both loaded)
+    _storage_configured = True
     Storage.path = Path(tempfile.mkdtemp(prefix='nicegui-test-storage-')).resolve()
     app.storage = Storage()  # rebuild app.storage so its FilePersistentDict picks up the new path
     config.addinivalue_line('markers', 'nicegui_main_file: specify the main file for the test')
@@ -29,10 +31,11 @@ def pytest_configure(config: pytest.Config) -> None:
 
 def pytest_unconfigure(config: pytest.Config) -> None:  # pylint: disable=unused-argument
     """Clean up session-unique storage directory."""
-    if Storage.path is None:
+    global _storage_configured  # pylint: disable=global-statement # noqa: PLW0603
+    if not _storage_configured:
         return
     shutil.rmtree(Storage.path, ignore_errors=True)
-    Storage.path = None  # type: ignore[assignment]
+    _storage_configured = False
 
 
 def get_path_to_main_file(request: pytest.FixtureRequest) -> Path | None:

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -1,3 +1,4 @@
+import atexit
 import shutil
 import tempfile
 from pathlib import Path
@@ -10,8 +11,6 @@ from . import general
 
 # pylint: disable=redefined-outer-name
 
-_storage_configured = False  # separate sentinel so plain `import nicegui.testing` doesn't clobber Storage.path
-
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add pytest option for main file."""
@@ -20,22 +19,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 def pytest_configure(config: pytest.Config) -> None:
     """Set up a session-unique storage path and register the "nicegui_main_file" marker."""
-    global _storage_configured  # pylint: disable=global-statement # noqa: PLW0603
-    if _storage_configured:
-        return  # already configured (e.g. plugin.py + user_plugin.py both loaded)
-    _storage_configured = True
     Storage.path = Path(tempfile.mkdtemp(prefix='nicegui-test-storage-')).resolve()
+    atexit.register(shutil.rmtree, Storage.path, ignore_errors=True)  # session-end cleanup
     app.storage = Storage()  # rebuild app.storage so its FilePersistentDict picks up the new path
     config.addinivalue_line('markers', 'nicegui_main_file: specify the main file for the test')
-
-
-def pytest_unconfigure(config: pytest.Config) -> None:  # pylint: disable=unused-argument
-    """Clean up session-unique storage directory."""
-    global _storage_configured  # pylint: disable=global-statement # noqa: PLW0603
-    if not _storage_configured:
-        return
-    shutil.rmtree(Storage.path, ignore_errors=True)
-    _storage_configured = False
 
 
 def get_path_to_main_file(request: pytest.FixtureRequest) -> Path | None:

--- a/nicegui/testing/plugin.py
+++ b/nicegui/testing/plugin.py
@@ -1,5 +1,5 @@
 # pylint: disable=unused-import
-from .general_fixtures import nicegui_reset_globals, pytest_addoption, pytest_unconfigure  # noqa: F401
+from .general_fixtures import nicegui_reset_globals, pytest_addoption  # noqa: F401
 from .screen_plugin import (  # noqa: F401
     nicegui_chrome_options,
     nicegui_driver,

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -15,7 +15,6 @@ from .filelock import FileLock
 from .general_fixtures import (  # noqa: F401  # pylint: disable=unused-import
     nicegui_reset_globals,
     pytest_addoption,
-    pytest_unconfigure,
 )
 from .general_fixtures import pytest_configure as _general_pytest_configure
 from .screen import Screen

--- a/nicegui/testing/user_plugin.py
+++ b/nicegui/testing/user_plugin.py
@@ -12,7 +12,6 @@ from .general_fixtures import (  # noqa: F401  # pylint: disable=unused-import
     get_path_to_main_file,
     pytest_addoption,
     pytest_configure,
-    pytest_unconfigure,
 )
 from .user import User
 from .user_simulation import prepare_simulation, user_simulation

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -35,3 +35,13 @@ def test_module_access_does_not_import_others():
         sys.exit('button' in sys.modules.keys())
     ''')], capture_output=True, text=True, timeout=30, check=False)
     assert result.returncode == 0, 'button should not be imported when accessing label'
+
+
+def test_importing_nicegui_testing_does_not_clobber_storage_path():
+    result = subprocess.run(['python3', '-c', dedent('''\
+        from nicegui.storage import Storage
+        orig = Storage.path
+        from nicegui.testing import Screen, User  # noqa: F401
+        assert Storage.path == orig, f"Storage.path was clobbered: {orig!r} -> {Storage.path!r}"
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
### Motivation

Fixes zauberzeug/nicegui#6061. PR #5960 introduced a module-level `Storage.path = None` assignment in `nicegui/testing/general_fixtures.py` intended as a "not configured yet" sentinel for pytest. But that line executes on plain `import nicegui.testing` — not just under pytest — so any production app whose import graph reaches the testing module has its `Storage.path` clobbered to `None`.

Concretely, NiceGUI's own docs site does this: `website/documentation/content/screen_documentation.py:2` does `from nicegui.testing import Screen`, which transitively imports `general_fixtures`, which sets `Storage.path = None`. The next `app.storage.user` access then crashes in `Storage._create_persistent_dict` at `nicegui/storage.py:98`:

```
TypeError: unsupported operand type(s) for /: 'NoneType' and 'str'
```

Empirical repro (pre-fix):

```python
>>> from nicegui.storage import Storage
>>> Storage.path
PosixPath('/.../.nicegui')
>>> from nicegui.testing import Screen
>>> Storage.path
None
```

### Implementation

Stop mutating `Storage.path` at module-level. The tempdir creation now happens only inside `pytest_configure`, and its cleanup is registered via `atexit.register(shutil.rmtree, ..., ignore_errors=True)` — the same pattern already used in `screen_plugin.py` for `DOWNLOAD_DIR`. This lets us drop `pytest_unconfigure` entirely (and its three re-exports in `plugin.py`, `user_plugin.py`, `screen_plugin.py`).

Net change in `general_fixtures.py`: +1 import, -1 module-level assignment, -1 hook function, -1 sentinel variable (after design iteration; see below).

A regression test is added in `tests/test_lazy_imports.py` (subprocess pattern matches existing `test_module_access_does_not_import_others`):

```python
def test_importing_nicegui_testing_does_not_clobber_storage_path():
    result = subprocess.run(['python3', '-c', dedent('''\
        from nicegui.storage import Storage
        orig = Storage.path
        from nicegui.testing import Screen, User  # noqa: F401
        assert Storage.path == orig, ...
    ''')], capture_output=True, text=True, timeout=30, check=False)
    assert result.returncode == 0, result.stderr
```

Verified the test fails on pre-fix code (stash/unstash) and passes after — not vacuous.

<details>
<summary>Design discussion: why atexit instead of a `_storage_configured` boolean + `pytest_unconfigure`?</summary>

The first commit on this branch used a separate module-level `_storage_configured: bool` as the sentinel and kept a symmetric `pytest_unconfigure` hook for cleanup. The second commit replaces that with `atexit.register` and drops the hook.

**Alternatives considered for replacing the broken `Storage.path is None` sentinel:**

1. **Module-level `_storage_configured` boolean** — clean, but adds a new mutable module-level variable.
2. **Capture `_INITIAL_STORAGE_PATH = Storage.path` at import, compare in `pytest_configure`** — still a new variable, and fragile if a user has set `Storage.path` themselves before pytest runs.
3. **Class attribute on `Storage`** — leaks pytest concerns into production class. Rejected.
4. **`pytest.StashKey`** — proper pytest idiom but still introduces a module-level `StashKey` instance, same effective scope as a bool.
5. **Function attribute (`pytest_configure._called`)** — poor discoverability. Rejected.
6. **Drop the guard, use `atexit.register` for cleanup** — zero new module-level variables, matches existing `screen_plugin.py` pattern. **Chosen.**

**Trade-off vs the boolean + `pytest_unconfigure` approach:**
- For one-shot `pytest` invocations (CI, normal dev runs): identical behavior.
- For in-process repeat usage (IDE "re-run tests", `pytest --looponfail`, some `pytest-xdist` setups): cleanup is deferred to process exit instead of pytest session end. Leaked tempdirs accumulate in the system temp dir until the Python process dies. The directories are small (empty or a few JSON files) and OS-GC'd eventually.

**Why the dual-plugin re-entry guard wasn't necessary:**
The previous "is already configured" check guarded against `pytest_plugins = ['nicegui.testing.plugin', 'nicegui.testing.user_plugin']` both being loaded, which would call `_general_pytest_configure` twice. NiceGUI's own `tests/conftest.py` loads only `nicegui.testing.plugin` (which already re-exports user-plugin fixtures), and the dual-load is redundant by design — it would cause fixture redefinition warnings. Without the guard, the worst case is one extra `tempfile.mkdtemp` call whose result is immediately shadowed; the orphaned dir is still rmtree'd at exit via its own `atexit` registration.

I'm happy to revert to the boolean approach if you prefer the deterministic per-session cleanup.

</details>

### Validation

- `pytest tests/test_storage.py tests/test_lazy_imports.py tests/test_main_file_marker.py tests/test_user_simulation.py` → 102 passed / 2 xfailed (pre-existing).
- `ruff check`, `pylint`, `mypy` on changed files → clean.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added (regression test in `tests/test_lazy_imports.py`).
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API.

---

Draft against `evnchn/nicegui:main` for review/finetune before upstreaming to `zauberzeug/nicegui`. Two commits are currently on the branch; squash on merge if preferred.