### PR TITLE
Replace misleading reload error for `python -m <pkg>` (#6066)

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -1,6 +1,8 @@
 import asyncio
 import inspect
 import mimetypes
+import multiprocessing
+import sys
 import time
 import urllib.parse
 from contextlib import asynccontextmanager
@@ -122,6 +124,11 @@ def _get_esm(key: str, path: str) -> FileResponse:
 async def _startup() -> None:
     """Handle the startup event."""
     if not app.config.has_run_config:
+        argv0 = Path(sys.argv[0]) if sys.argv else Path()
+        is_dash_m_package = argv0.name == '__main__.py' and (argv0.parent / '__init__.py').is_file()
+        if multiprocessing.current_process().name != 'MainProcess' and is_dash_m_package:
+            raise RuntimeError(f'\n\nAuto-reload is not supported with `python -m {argv0.parent.name}`.\n'
+                               f'Pass `reload=False` to ui.run() or run `python {argv0.parent.name}/__main__.py` directly.')
         raise RuntimeError('\n\n'
                            'You must call ui.run() to start the server.\n'
                            'If ui.run() is behind a main guard\n'


### PR DESCRIPTION
### Motivation

Closes [#6066](https://github.com/zauberzeug/nicegui/issues/6066).

When launching as `python -m <pkg>` (a package directory with `__init__.py` + `__main__.py`), `ui.run(reload=True)` fails with a misleading error that tells the user to fix a main guard. The user has no main guard to fix, and CPython will refuse to re-run `__main__.py` regardless.

<details>
<summary>The current (misleading) error</summary>

```
You must call ui.run() to start the server.
If ui.run() is behind a main guard
   if __name__ == "__main__":
remove the guard or replace it with
   if __name__ in {"__main__", "__mp_main__"}:
to allow for multiprocessing.
```

</details>

This same trap has been reported repeatedly: #181, #5280, #3769, #5939, and now #6066.

### Root cause

`multiprocessing.spawn._fixup_main_from_name` (`Lib/multiprocessing/spawn.py`) returns early when the parent was launched as `-m <pkg>`, per CPython policy:

> `__main__.py` files for packages, directories, zip archives, etc, run their "main only" code unconditionally, so we don't even try to populate anything in `__main__`, nor do we make any changes to `__main__` attributes

NiceGUI's reload model assumes the user's top-level script re-executes in the spawn child (that's how `app.config.has_run_config` gets set there). For `-m package`, spawn declines to re-execute, so `has_run_config` stays `False` → the misleading error fires.

### Implementation

In `_startup()`, before the legacy error, detect the specific failure mode and raise a targeted message naming the package and pointing at the two working alternatives. The legacy error still fires for the original main-guard case.

<details>
<summary>Detection signals (and why <code>sys.argv[0]</code> is the only reliable one in the spawn child)</summary>

A probe in the spawn child showed:

```
proc='SpawnProcess-1'
__main__.__spec__ = None
__main__.__file__ = None
sys.argv[0]       = '/private/tmp/ng-test/xxx/__main__.py'
```

`__spec__` and `__file__` are `None` because spawn refused to fix them up. `sys.argv[0]` is inherited from the parent unchanged. Combined with the `__init__.py` sibling check, this uniquely identifies a `-m <pkg>` invocation without false positives on regular scripts.

</details>

### Empirical verification

| Invocation | Outcome |
|---|---|
| `python -m xxx` (broken case) | **New** targeted error fires |
| `python script.py` | `NiceGUI ready` ✓ (new branch correctly skipped — `has_run_config` is True) |
| `python xxx/__main__.py` (direct) | `NiceGUI ready` ✓ (spawn's `_fixup_main_from_path` runs the file) |
| `python noguard.py` with a legitimate `if __name__ == "__main__":` guard | **Legacy** "remove the guard" error fires unchanged |

The new error reads:

```
Auto-reload is not supported with `python -m xxx`.
Pass `reload=False` to ui.run() or run `python xxx/__main__.py` directly.
```

### Alternatives considered

A **salvager** that re-runs the user's package via `runpy.run_module(pkg, run_name='__mp_main__')` at module load time was prototyped and confirmed to work end-to-end (including across multiple WatchFiles reload cycles — verified 3 consecutive edits, browser saw `MARKER_V1` → `V2` → `V3`).

It was rejected for being too aggressive:
- bypasses CPython's deliberate spawn policy
- runs user code as a side effect of `import nicegui`
- adds a 30-line helper to handle one obscure invocation form

An accurate error is a smaller, more honest change.

<details>
<summary>The full salvager prototype (~30 lines) — for contrast with the 7-line fix in this PR</summary>

```python
def _salvage_module_reload_child() -> None:
    """Workaround for `python -m <pkg>` + reload=True (issue #6066).

    multiprocessing.spawn._fixup_main_from_name refuses to re-execute __main__.py
    files in spawn children, so the reload child never runs the user's code and
    `app.config.has_run_config` stays False. We detect that situation here (at
    import time, before lifespan starts) and re-run the user's package.
    """
    import multiprocessing
    import os
    import runpy
    import sys
    if multiprocessing.current_process().name == 'MainProcess':
        return
    if app.config.has_run_config:
        return
    argv0 = sys.argv[0] if sys.argv else ''
    if not argv0.endswith('__main__.py'):
        return
    pkg_dir = os.path.dirname(argv0)
    if not os.path.exists(os.path.join(pkg_dir, '__init__.py')):
        return
    pkg_name = os.path.basename(pkg_dir)
    parent = os.path.dirname(pkg_dir)
    while os.path.exists(os.path.join(parent, '__init__.py')):
        pkg_name = os.path.basename(parent) + '.' + pkg_name
        parent = os.path.dirname(parent)
    runpy.run_module(pkg_name, run_name='__mp_main__', alter_sys=True)


_salvage_module_reload_child()
```

Placed at module level of `nicegui/nicegui.py`, after `app` is constructed.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests not added — the failure surfaces in a uvicorn-reload subprocess driven by the user's invocation form, which the existing test harness doesn't model.
- [x] Documentation not necessary — behavior is unchanged for all working invocations; only the error message for one specific broken invocation is improved.
- [x] No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)