### PR TITLE
Stop injecting sad-face 404 when ui.sub_pages handles 404 (fixes upstream #6069)

### DIFF
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -202,8 +202,6 @@ class page:
                     task.add_done_callback(check_for_late_return_value)
 
             if not await client.sub_pages_router._can_resolve_full_path(client):  # pylint: disable=protected-access
-                # The SubPages element renders its own 404 label inside the page; don't inject
-                # a sibling sad-face block on top of user-supplied chrome. Just return 404 status.
                 log.warning(f'{request.url} not found')
                 return client.build_response(request, 404)
 

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -7,11 +7,10 @@ from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from fastapi import HTTPException, Request, Response
+from fastapi import Request, Response
 
 from . import background_tasks, binding, core, helpers
 from .client import Client, ClientConnectionTimeout
-from .error import error_content
 from .favicon import create_favicon_route
 from .language import Language
 from .logging import log
@@ -203,10 +202,9 @@ class page:
                     task.add_done_callback(check_for_late_return_value)
 
             if not await client.sub_pages_router._can_resolve_full_path(client):  # pylint: disable=protected-access
-                # Handle 404 gracefully without re-raising exception (similar to 404 handler when no root function)
+                # The SubPages element renders its own 404 label inside the page; don't inject
+                # a sibling sad-face block on top of user-supplied chrome. Just return 404 status.
                 log.warning(f'{request.url} not found')
-                with client:
-                    error_content(404, HTTPException(404, f'{client.sub_pages_router.current_path} not found'))
                 return client.build_response(request, 404)
 
             if isinstance(result, Response):  # NOTE if setup returns a response, we don't need to render the page

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -976,7 +976,7 @@ def test_on_path_changed_event(screen: Screen):
     assert calls == {'index': 2, 'main': 1, 'other': 2}
 
     screen.open('/bad_path')
-    screen.should_contain('HTTPException: 404: /bad_path not found')
+    screen.should_contain('404: sub page /bad_path not found')
     assert paths == ['/other']
     assert calls == {'index': 3, 'main': 2, 'other': 2}
 
@@ -1089,6 +1089,25 @@ def test_navigate_from_404_to_root_path(screen: Screen):
     screen.should_contain('main page')
 
 
+def test_navigate_from_initial_404_does_not_leak_sad_face(screen: Screen):
+    # Regression test for https://github.com/zauberzeug/nicegui/issues/6069
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        ui.link('Go to home', '/')
+        ui.sub_pages({'/': lambda: ui.label('main page')})
+
+    screen.allowed_js_errors.append('/bad_path - Failed to load resource')
+    screen.open('/bad_path')
+    screen.should_contain('404: sub page /bad_path not found')
+    screen.should_not_contain("This page doesn't exist.")
+
+    screen.click('Go to home')
+    screen.should_contain('main page')
+    screen.should_not_contain('404: sub page /bad_path not found')
+    screen.should_not_contain("This page doesn't exist.")
+
+
 def test_http_404_on_initial_request(screen: Screen):
     @ui.page('/')
     @ui.page('/{_:path}')
@@ -1107,7 +1126,7 @@ def test_http_404_on_initial_request(screen: Screen):
     screen.should_contain('main page')
 
     screen.open('/bad_path')
-    screen.should_contain('HTTPException: 404: /bad_path not found')
+    screen.should_contain('404: sub page /bad_path not found')
 
 
 def test_http_404_on_initial_request_with_async_page_builder(screen: Screen):
@@ -1128,7 +1147,7 @@ def test_http_404_on_initial_request_with_async_page_builder(screen: Screen):
     screen.should_contain('main page')
 
     screen.open('/bad_path')
-    screen.should_contain('HTTPException: 404: /bad_path not found')
+    screen.should_contain('404: sub page /bad_path not found')
 
 
 def test_http_404_on_initial_request_with_async_sub_page_builder(screen: Screen):
@@ -1160,7 +1179,7 @@ def test_http_404_on_initial_request_with_async_sub_page_builder(screen: Screen)
     screen.should_contain('sub sub page')
 
     screen.open('/bad_path')
-    screen.should_contain('HTTPException: 404: /bad_path not found')
+    screen.should_contain('404: sub page /bad_path not found')
 
 
 def test_http_404_with_root_function_and_sub_pages(screen: Screen):

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -1090,7 +1090,7 @@ def test_navigate_from_404_to_root_path(screen: Screen):
 
 
 def test_navigate_from_initial_404_does_not_leak_sad_face(screen: Screen):
-    # Regression test for https://github.com/zauberzeug/nicegui/issues/6069
+    # regression test for #6069
     @ui.page('/')
     @ui.page('/{_:path}')
     def index():


### PR DESCRIPTION
## Summary

Upstream bug: [zauberzeug/nicegui#6069](https://github.com/zauberzeug/nicegui/issues/6069). When a page handler returns a 404 because `ui.sub_pages` can't resolve the path, `nicegui/page.py` injects `error_content` (the sad-face block) as a *sibling* of the user's root() chrome. SPA navigation via `sub_pages_router` only re-renders `SubPages` elements, so the sibling sad-face leaks past the recovered navigation.

The fix is to drop the `error_content` injection entirely. Rationale:
- When `root()` contains `ui.sub_pages`, the rest of root() is user-supplied chrome. The framework should not inject a styled 404 page on top of it.
- `SubPages` already renders its own `404: sub page X not found` label inside its own slot, which is naturally cleaned up by `_show()` on SPA navigation.
- HTTP 404 status is still returned by `client.build_response(request, 404)`, so bookmarks/SEO/curl are unaffected.

This matches Falko's "fix 1" proposal in the issue.

## Changes

- `nicegui/page.py`: delete the `with client: error_content(...)` block and the now-unused `HTTPException` / `error_content` imports.
- `tests/test_sub_pages.py`:
  - Update 4 existing assertions that depended on the sad-face text (`HTTPException: 404: /bad_path not found` → `404: sub page /bad_path not found`).
  - Add `test_navigate_from_initial_404_does_not_leak_sad_face` as a regression test for #6069: direct-URL hit to /bad_path, then click home link, assert sad-face is gone.

## Follow-up (not in this PR)

The inner SubPages 404 label is debug-quality plain text. A separate issue should track making it customizable — e.g. a `not_found_builder=` callback on `ui.sub_pages` or a `'*'` wildcard route.

## Test plan

- [ ] Fork CI runs `tests/test_sub_pages.py` and all four updated assertions pass.
- [ ] New `test_navigate_from_initial_404_does_not_leak_sad_face` passes.
- [ ] Manually confirm the original repro from #6069: `/some_other_page` direct hit shows only the small 404 line inside chrome (no sad-face), and clicking `Go to home` leaves only the home content (no stale 404 label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)