### PR TITLE
Skip autoSizeStrategy when columns use flex

### DIFF
--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -49,7 +49,8 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         super().__init__()
         self._props['options'] = {
             'theme': theme or 'quartz',
-            **({'autoSizeStrategy': {'type': 'fitGridWidth'}} if auto_size_columns else {}),
+            **({'autoSizeStrategy': {'type': 'fitGridWidth'}}
+               if auto_size_columns and not self._uses_flex(options) else {}),
             **options,
         }
         self._props['html-columns'] = html_columns[:]
@@ -78,6 +79,18 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                 "    'editable': True,\n"
                 'Please migrate ASAP as the backwards-compatibility will be removed in NiceGUI 4.0.'
             )
+
+    @staticmethod
+    def _uses_flex(options: dict) -> bool:
+        """Whether the grid requests flex column sizing.
+
+        ``flex`` and ``autoSizeStrategy`` are mutually exclusive in AG Grid: when both are set,
+        AG Grid ignores ``flex`` (and with some row models the grid renders blank). See #5087.
+        """
+        if options.get('defaultColDef', {}).get('flex') is not None:
+            return True
+        return any(isinstance(col, dict) and col.get('flex') is not None
+                   for col in options.get('columnDefs', []))
 
     @classmethod
     def from_pandas(cls,


### PR DESCRIPTION
### Motivation

Addresses #5087 — `ui.aggrid` with `defaultColDef={'flex': 1}` and the infinite row model renders a **blank** grid on NiceGUI 3.x (AG Grid 34.2.0). The data actually loads (rows + headers are in the DOM with correct text), but every cell ends up computed `visibility: hidden`, so the user sees nothing.

Root cause: NiceGUI injects `autoSizeStrategy: {'type': 'fitGridWidth'}` by default (`auto_size_columns=True`). `flex` and `autoSizeStrategy` are mutually exclusive in AG Grid — it warns `colDef.flex is not supported with gridOptions.autoSizeStrategy` ([column-sizing docs](https://www.ag-grid.com/javascript-data-grid/column-sizing/)) — and the combination breaks rendering under the infinite row model. NiceGUI 2.x (AG Grid 32.1.0) tolerated it; the 2→3 AG Grid bump (32.1.0 → 34.2.0) surfaced it. Verified empirically that `auto_size_columns=False` already fixes it on both 3.0.4 and 3.12.1.

### Implementation

Don't inject the default `autoSizeStrategy` when the user's columns already request `flex` — `flex` *is* a sizing strategy, so the default is redundant and, here, harmful. A small `_uses_flex(options)` helper checks `defaultColDef.flex` and any `columnDefs[*].flex`.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [ ] The implementation is complete. (See rough edges below — opening as a discussion brick.)
- [x] This PR does not address a security issue.
- [ ] Pytests have been added/updated. (Not yet — see below.)
- [x] Documentation has been added/updated or is not necessary.
- [ ] No breaking changes to the public API or migration steps are described above. (See edge below.)

---

🧱 **This is a brick, not jade** — deliberately rough to start the conversation:

- **Shallow flex detection**: only `defaultColDef.flex` and top-level `columnDefs[*].flex`. Doesn't recurse into column-group `children`, nor handle `flex` passed as a `:flex` dynamic-property string.
- **Property-getter inconsistency**: the `auto_size_columns` getter reads `autoSizeStrategy` back out of `options`, so when flex is present `grid.auto_size_columns` now reports `False` even though `True` was passed. Honest (reflects real state) but possibly surprising.
- **No tests yet** — will add once an approach is chosen.
- **Companion PR** takes the opposite tack: *warn* and let the user flip `auto_size_columns=False`, instead of silently skipping. They're alternatives — pick one, or combine (skip + a debug log).

Open question for @falkoschindler: silently skip (this PR), warn-and-let-user-fix (companion), or both?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
