### PR TITLE
Warn when auto_size_columns conflicts with flex columns

### DIFF
--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -47,6 +47,14 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         self._migrate_deprecated_checkbox_renderer(options)  # DEPRECATED: remove in NiceGUI 4.0
 
         super().__init__()
+        if auto_size_columns and self._uses_flex(options):
+            helpers.warn_once(
+                'AG Grid: auto_size_columns=True injects autoSizeStrategy, which AG Grid ignores '
+                'when columns use "flex" — and with some row models (e.g. the infinite row model) '
+                'this can leave the grid blank.\n'
+                'Pass auto_size_columns=False to keep your flex sizing.\n'
+                'See https://github.com/zauberzeug/nicegui/issues/5087'
+            )
         self._props['options'] = {
             'theme': theme or 'quartz',
             **({'autoSizeStrategy': {'type': 'fitGridWidth'}} if auto_size_columns else {}),
@@ -78,6 +86,18 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                 "    'editable': True,\n"
                 'Please migrate ASAP as the backwards-compatibility will be removed in NiceGUI 4.0.'
             )
+
+    @staticmethod
+    def _uses_flex(options: dict) -> bool:
+        """Whether the grid requests flex column sizing.
+
+        ``flex`` and ``autoSizeStrategy`` are mutually exclusive in AG Grid: when both are set,
+        AG Grid ignores ``flex`` (and with some row models the grid renders blank). See #5087.
+        """
+        if options.get('defaultColDef', {}).get('flex') is not None:
+            return True
+        return any(isinstance(col, dict) and col.get('flex') is not None
+                   for col in options.get('columnDefs', []))
 
     @classmethod
     def from_pandas(cls,


### PR DESCRIPTION
### Motivation

Alternative take on #5087 (companion to #160). `ui.aggrid` with `defaultColDef={'flex': 1}` + the infinite row model renders a **blank** grid on NiceGUI 3.x (AG Grid 34.2.0): data loads, but cells end up `visibility: hidden`.

Root cause: NiceGUI injects `autoSizeStrategy: {'type': 'fitGridWidth'}` by default (`auto_size_columns=True`), and AG Grid ignores `flex` when `autoSizeStrategy` is set (it warns `colDef.flex is not supported with gridOptions.autoSizeStrategy`). The trouble: AG Grid's warning names `autoSizeStrategy` — an option the **user never wrote** (NiceGUI injected it) — and on NiceGUI 3.0.x the `sizeColumnsToFit()` path emits *no* warning at all. So the user gets a blank grid with no actionable signal pointing at the lever they control.

### Implementation

Where `auto_size_columns=True` meets flex columns, emit a `helpers.warn_once(...)` (same idiom as the existing `checkboxRenderer` deprecation) naming the actual fix: `auto_size_columns=False`. Behavior is unchanged — this only adds the warning. Shares the `_uses_flex(options)` helper with #160.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [ ] The implementation is complete. (Discussion brick — see below.)
- [x] This PR does not address a security issue.
- [ ] Pytests have been added/updated. (Not yet.)
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.

---

🧱 **Brick, not jade** — rough first pass:

- **This is the opposite philosophy to #160**: #160 silently *fixes* (skip autoSizeStrategy), this one *warns* and lets the user decide. Pick one — or combine (skip + a quieter debug log).
- **Shallow flex detection** (shared helper): only `defaultColDef.flex` and top-level `columnDefs[*].flex`; no column-group recursion or `:flex` dynamic strings.
- **Wording is a draft** — happy to tighten.
- **No tests yet.**

@falkoschindler — warn (this) vs auto-skip (#160) vs both?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
