### PR TITLE
Default auto_size_columns to None and skip it for flex columns

### DIFF
--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -25,7 +25,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                  options: dict, *,
                  html_columns: list[int] = DEFAULT_PROP | [],
                  theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
-                 auto_size_columns: bool = True,
+                 auto_size_columns: bool | None = None,
                  modules: Literal['community', 'enterprise'] | list[str] = 'community',
                  ) -> None:
         """AG Grid
@@ -38,7 +38,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         :param options: dictionary of AG Grid options
         :param html_columns: list of columns that should be rendered as HTML (default: ``[]``)
         :param theme: AG Grid theme "quartz", "balham", "material", or "alpine" (default: ``options['theme']`` or "quartz")
-        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``True``)
+        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``None``, i.e. fit to width unless columns use ``flex``)
         :param modules: either "community", "enterprise", or a list of `AG Grid Modules <https://www.ag-grid.com/javascript-data-grid/modules/>`_ (default: "community")
         """
         if not isinstance(modules, list):
@@ -47,6 +47,14 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         self._migrate_deprecated_checkbox_renderer(options)  # DEPRECATED: remove in NiceGUI 4.0
 
         super().__init__()
+        if auto_size_columns is None:
+            auto_size_columns = not self._uses_flex(options)  # auto: flex columns size themselves
+        elif auto_size_columns and self._uses_flex(options):
+            helpers.warn_once(
+                'AG Grid: auto_size_columns=True is incompatible with columns using "flex" '
+                '(AG Grid ignores flex when autoSizeStrategy is set, and the grid may render blank).\n'
+                'Use either flex or auto_size_columns, not both.'
+            )
         self._props['options'] = {
             'theme': theme or 'quartz',
             **({'autoSizeStrategy': {'type': 'fitGridWidth'}} if auto_size_columns else {}),
@@ -79,12 +87,22 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                 'Please migrate ASAP as the backwards-compatibility will be removed in NiceGUI 4.0.'
             )
 
+    @staticmethod
+    def _uses_flex(options: dict) -> bool:
+        """Whether any column requests flex sizing (mutually exclusive with autoSizeStrategy).
+
+        Detects both the literal ``flex`` key and the dynamic ``:flex`` property form,
+        which NiceGUI converts to ``flex`` on the client (see #5087).
+        """
+        return any(col.get('flex') is not None or ':flex' in col
+                   for col in [options.get('defaultColDef', {}), *options.get('columnDefs', [])])
+
     @classmethod
     def from_pandas(cls,
                     df: 'pd.DataFrame', *,
                     html_columns: list[int] = [],  # noqa: B006
                     theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
-                    auto_size_columns: bool = True,
+                    auto_size_columns: bool | None = None,
                     options: dict = {},  # noqa: B006
                     modules: Literal['community', 'enterprise'] | list[str] = 'community',
                     ) -> Self:
@@ -103,7 +121,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         :param df: Pandas DataFrame
         :param html_columns: list of columns that should be rendered as HTML (default: ``[]``, *added in version 2.19.0*)
         :param theme: AG Grid theme "quartz", "balham", "material", or "alpine" (default: ``options['theme']`` or "quartz")
-        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``True``)
+        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``None``, i.e. fit to width unless columns use ``flex``)
         :param options: dictionary of additional AG Grid options
         :param modules: either "community", "enterprise", or a list of `AG Grid Modules <https://www.ag-grid.com/javascript-data-grid/modules/>`_ (default: "community")
         :return: AG Grid element
@@ -142,7 +160,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                     df: 'pl.DataFrame', *,
                     html_columns: list[int] = [],  # noqa: B006
                     theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
-                    auto_size_columns: bool = True,
+                    auto_size_columns: bool | None = None,
                     options: dict = {},  # noqa: B006
                     modules: Literal['community', 'enterprise'] | list[str] = 'community',
                     ) -> Self:
@@ -156,7 +174,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         :param df: Polars DataFrame
         :param html_columns: list of columns that should be rendered as HTML (default: ``[]``, *added in version 2.19.0*)
         :param theme: AG Grid theme "quartz", "balham", "material", or "alpine" (default: ``options['theme']`` or "quartz")
-        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``True``)
+        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``None``, i.e. fit to width unless columns use ``flex``)
         :param options: dictionary of additional AG Grid options
         :param modules: either "community", "enterprise", or a list of `AG Grid Modules <https://www.ag-grid.com/javascript-data-grid/modules/>`_ (default: "community")
         :return: AG Grid element

--- a/tests/test_aggrid.py
+++ b/tests/test_aggrid.py
@@ -11,7 +11,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import Event, app, ui
-from nicegui.testing import Screen
+from nicegui.testing import Screen, User
 
 
 def test_update_table(screen: Screen):
@@ -380,3 +380,23 @@ def test_pandas_with_index(screen: Screen, index: Any, expected: list[str], unex
         screen.should_contain(item)
     for item in unexpected:
         screen.should_not_contain(item)
+
+
+async def test_auto_size_columns_vs_flex(user: User):
+    """auto_size_columns=None must skip autoSizeStrategy for flex columns, but respect explicit values (#5087)."""
+    grids: dict = {}
+
+    @ui.page('/')
+    def page():
+        grids['default'] = ui.aggrid({'columnDefs': [{'field': 'a'}]})
+        grids['flex'] = ui.aggrid({'defaultColDef': {'flex': 1}, 'columnDefs': [{'field': 'a'}]})
+        grids['dynamic_flex'] = ui.aggrid({'columnDefs': [{'field': 'a', ':flex': '1'}]})
+        grids['forced'] = ui.aggrid({'defaultColDef': {'flex': 1}}, auto_size_columns=True)
+        grids['off'] = ui.aggrid({'columnDefs': [{'field': 'a'}]}, auto_size_columns=False)
+
+    await user.open('/')
+    assert 'autoSizeStrategy' in grids['default'].options, 'None default without flex should fit-to-width'
+    assert 'autoSizeStrategy' not in grids['flex'].options, 'None default with flex should skip autoSizeStrategy (#5087)'
+    assert 'autoSizeStrategy' not in grids['dynamic_flex'].options, 'dynamic :flex should also skip autoSizeStrategy'
+    assert 'autoSizeStrategy' in grids['forced'].options, 'explicit auto_size_columns=True must be respected'
+    assert 'autoSizeStrategy' not in grids['off'].options, 'explicit auto_size_columns=False must be respected'


### PR DESCRIPTION
### Motivation

Fixes #5087. `ui.aggrid` with `defaultColDef={'flex': 1}` + the infinite row model renders a **blank** grid on NiceGUI 3.x (AG Grid 34.2.0): the data loads (rows + headers are in the DOM), but cells end up `visibility: hidden`. Cause — NiceGUI injects `autoSizeStrategy: {'type': 'fitGridWidth'}` by default (`auto_size_columns=True`), and AG Grid ignores `flex` when `autoSizeStrategy` is set ([column-sizing docs](https://www.ag-grid.com/javascript-data-grid/column-sizing/); it warns `colDef.flex is not supported with gridOptions.autoSizeStrategy`). NiceGUI 2.x (AG Grid 32.1.0) tolerated it; the 2→3 AG Grid bump surfaced it.

### Implementation

Change `auto_size_columns` from `bool = True` to `bool | None = None`:

| Value | Behavior |
| --- | --- |
| `None` (default) | **auto** — fit-to-width unless columns use `flex` (then flex wins). Fixes #5087 for everyone who never set the param. |
| `True` (explicit) | always inject `autoSizeStrategy` — explicit intent respected (warns once if it conflicts with `flex`). |
| `False` (explicit) | never inject (unchanged). |

A `_uses_flex(options)` helper detects flex sizing in `defaultColDef`/`columnDefs`, including the dynamic `:flex` property form (NiceGUI converts it to `flex` client-side). The `auto_size_columns` property getter is unchanged and stays truthful (explicit `True` actually injects, so there's no get/set inconsistency). The `None` → "do the sensible thing" mirrors existing patterns in the codebase (`storage.py` "Ignoring … because …"; the `checkboxRenderer` migrate-and-warn in this same file).

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated. (Browser-free `user`-fixture test asserting `autoSizeStrategy` presence/absence across `None`/`True`/`False` × flex/no-flex/`:flex`.)
- [ ] Documentation has been added/updated or is not necessary. (Docstrings updated; an aggrid `flex` demo could be added — flagging for maintainer preference.)
- [ ] No breaking changes to the public API or migration steps are described above. (Default `True`→`None`; behavior unchanged for non-flex grids and for explicit `True`/`False`. Flex grids change from *blank* to *working*. Type widens `bool`→`bool | None`, backward-compatible.)

---

### Review & verification

Self-reviewed (fresh-context subagent + direct codebase checks). Two gaps were found and fixed before this was opened for human review:
1. `_uses_flex` originally missed the dynamic `:flex` property form, leaving #5087 reachable via that supported API — now detected (`9e88529`).
2. No test pinned the fix — added a browser-free `user`-fixture test (disconfirming: it fails without the `:flex` fix).

Verified locally: original #5087 MRE renders on this branch (blank on `main`); `ruff` + `mypy ./nicegui` + `pylint ./nicegui` (10.00/10) clean; the new test passes. The full selenium aggrid suite was **not** run locally (CI will) — but it contains no flex/auto-size cases, and non-flex grids receive byte-identical options (`None`→`not flex`→inject == old `True`→inject), so no regression path exists.

Supersedes #160 (silent skip) and #161 (warn-only), now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
