### PR TITLE
Add @js_action decorator for client-side open/close/toggle optimization (continuation of zauberzeug#5843)

### DIFF
--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -5,6 +5,7 @@ from .client import Client
 from .context import context
 from .element_filter import ElementFilter
 from .event import Event
+from .js_action import JsAction, js_action
 from .nicegui import app
 from .page_arguments import PageArguments
 from .version import __version__
@@ -15,6 +16,7 @@ __all__ = [
     'Client',
     'ElementFilter',
     'Event',
+    'JsAction',
     'PageArguments',
     '__version__',
     'app',
@@ -22,6 +24,7 @@ __all__ = [
     'context',
     'elements',
     'html',
+    'js_action',
     'run',
     'storage',
     'ui',

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -338,7 +338,7 @@ class Element(Visibility):
 
     def on(self,
            type: str,  # pylint: disable=redefined-builtin
-           handler: events.Handler[events.GenericEventArguments] | None = None,
+           handler: events.Handler[events.GenericEventArguments] | JsAction | None = None,
            args: None | Sequence[str] | Sequence[Sequence[str] | None] = None,
            *,
            throttle: float = 0.0,

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -25,6 +25,7 @@ from .dependencies import (
 )
 from .elements.mixins.visibility import Visibility
 from .event_listener import EventListener
+from .js_action import JsAction
 from .props import Props
 from .slot import Slot
 from .style import Style
@@ -362,6 +363,10 @@ class Element(Visibility):
         Note that the arguments ``throttle``, ``leading_events``, and ``trailing_events`` are only relevant
         when emitting events to the server.
 
+        If ``handler`` is a ``JsAction`` (from a ``@js_action``-decorated method), its ``js_handler``
+        runs on the client for instant feedback, while the Python handler runs on the server with
+        loopback suppressed to avoid redundant updates.
+
         *Updated in version 2.18.0: Both handlers can be specified at the same time.*
 
         :param type: name of the event (e.g. "click", "mousedown", or "update:model-value")
@@ -372,6 +377,9 @@ class Element(Visibility):
         :param trailing_events: whether to trigger the event handler after the last event occurrence (default: ``True``)
         :param js_handler: JavaScript function that is handling the event on the client (default: "(...args) => emit(...args)")
         """
+        if isinstance(handler, JsAction) and js_handler == '(...args) => emit(...args)':
+            js_handler = handler._js_handler  # pylint: disable=protected-access
+            handler = handler._call_without_loopback  # pylint: disable=protected-access
         if handler or js_handler:
             listener = EventListener(
                 element_id=self.id,

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -42,7 +42,7 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the button is clicked."""
         if has_js_action(callback):
-            self.on('click', callback, [])
+            self.on('click', callback, [])  # type: ignore[arg-type]
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -42,7 +42,7 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the button is clicked."""
         if has_js_action(callback):
-            self.on('click', callback, [])  # type: ignore[arg-type]
+            self.on('click', callback, [])
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -4,6 +4,7 @@ from typing_extensions import Self
 
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from ..events import ClickEventArguments, Handler, handle_event
+from ..js_action import has_js_action
 from .mixins.color_elements import BackgroundColorElement
 from .mixins.disableable_element import DisableableElement
 from .mixins.icon_element import IconElement
@@ -40,7 +41,10 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
 
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the button is clicked."""
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
+        if has_js_action(callback):
+            self.on('click', callback, [])
+        else:
+            self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self
 
     def _text_to_model_text(self, text: str) -> None:

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -2,6 +2,7 @@ from typing_extensions import Self
 
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from ..events import ClickEventArguments, Handler, ValueChangeEventArguments, handle_event
+from ..js_action import has_js_action, js_action
 from .mixins.color_elements import BackgroundColorElement
 from .mixins.disableable_element import DisableableElement
 from .mixins.icon_element import IconElement
@@ -54,20 +55,26 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
 
         *Added in version 2.22.0*
         """
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
+        if has_js_action(callback):
+            self.on('click', callback, [])
+        else:
+            self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self
 
     def _text_to_model_text(self, text: str) -> None:
         self._props['label'] = text
 
+    @js_action.value(True)
     def open(self) -> None:
         """Open the dropdown."""
         self.value = True
 
+    @js_action.value(False)
     def close(self) -> None:
         """Close the dropdown."""
         self.value = False
 
+    @js_action.toggle()
     def toggle(self) -> None:
         """Toggle the dropdown."""
         self.value = not self.value

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -57,7 +57,7 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
         *Added in version 2.22.0*
         """
         if has_js_action(callback):
-            self.on('click', callback, [])
+            self.on('click', callback, [])  # type: ignore[arg-type]
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -57,7 +57,7 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
         *Added in version 2.22.0*
         """
         if has_js_action(callback):
-            self.on('click', callback, [])  # type: ignore[arg-type]
+            self.on('click', callback, [])
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -11,6 +11,7 @@ from .mixins.value_element import ValueElement
 
 
 class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundColorElement, ValueElement):
+    LOOPBACK = False
 
     @resolve_defaults
     def __init__(self,

--- a/nicegui/elements/chip.py
+++ b/nicegui/elements/chip.py
@@ -57,7 +57,7 @@ class Chip(IconElement, ValueElement, TextElement, BackgroundColorElement, TextC
         """Add a callback to be invoked when the chip is clicked."""
         self._props['clickable'] = True
         if has_js_action(callback):
-            self.on('click', callback, [])
+            self.on('click', callback, [])  # type: ignore[arg-type]
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/chip.py
+++ b/nicegui/elements/chip.py
@@ -57,7 +57,7 @@ class Chip(IconElement, ValueElement, TextElement, BackgroundColorElement, TextC
         """Add a callback to be invoked when the chip is clicked."""
         self._props['clickable'] = True
         if has_js_action(callback):
-            self.on('click', callback, [])  # type: ignore[arg-type]
+            self.on('click', callback, [])
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/chip.py
+++ b/nicegui/elements/chip.py
@@ -2,6 +2,7 @@ from typing_extensions import Self
 
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from ..events import ClickEventArguments, Handler, ValueChangeEventArguments, handle_event
+from ..js_action import has_js_action
 from .mixins.color_elements import BackgroundColorElement, TextColorElement
 from .mixins.disableable_element import DisableableElement
 from .mixins.icon_element import IconElement
@@ -55,5 +56,8 @@ class Chip(IconElement, ValueElement, TextElement, BackgroundColorElement, TextC
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the chip is clicked."""
         self._props['clickable'] = True
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
+        if has_js_action(callback):
+            self.on('click', callback, [])
+        else:
+            self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -10,6 +10,7 @@ from .mixins.value_element import ValueElement
 
 
 class Dialog(ValueElement, component='dialog.js'):
+    LOOPBACK = False
 
     @resolve_defaults
     def __init__(self, *, value: bool = DEFAULT_PROPS['model-value'] | False) -> None:

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -5,6 +5,7 @@ from typing import Any
 from ..context import context
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..element import Element
+from ..js_action import js_action
 from .mixins.value_element import ValueElement
 
 
@@ -44,10 +45,12 @@ class Dialog(ValueElement, component='dialog.js'):
             self._submitted = asyncio.Event()
         return self._submitted
 
+    @js_action.value(True)
     def open(self) -> None:
         """Open the dialog."""
         self.value = True
 
+    @js_action.value(False)
     def close(self) -> None:
         """Close the dialog."""
         self.value = False

--- a/nicegui/elements/fab.py
+++ b/nicegui/elements/fab.py
@@ -4,6 +4,7 @@ from typing_extensions import Self
 
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import ClickEventArguments, Handler, handle_event
+from ..js_action import has_js_action, js_action
 from .mixins.color_elements import BackgroundColorElement
 from .mixins.disableable_element import DisableableElement
 from .mixins.icon_element import IconElement
@@ -35,14 +36,17 @@ class Fab(ValueElement, LabelElement, IconElement, BackgroundColorElement, Disab
         super().__init__(tag='q-fab', value=value, label=label, background_color=color, icon=icon)
         self._props['direction'] = direction
 
+    @js_action.value(True)
     def open(self) -> None:
         """Open the FAB."""
         self.value = True
 
+    @js_action.value(False)
     def close(self) -> None:
         """Close the FAB."""
         self.value = False
 
+    @js_action.toggle()
     def toggle(self) -> None:
         """Toggle the FAB."""
         self.value = not self.value
@@ -80,5 +84,8 @@ class FabAction(LabelElement, IconElement, BackgroundColorElement, DisableableEl
 
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the action element is clicked."""
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
+        if has_js_action(callback):
+            self.on('click', callback, [])
+        else:
+            self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/fab.py
+++ b/nicegui/elements/fab.py
@@ -86,7 +86,7 @@ class FabAction(LabelElement, IconElement, BackgroundColorElement, DisableableEl
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the action element is clicked."""
         if has_js_action(callback):
-            self.on('click', callback, [])  # type: ignore[arg-type]
+            self.on('click', callback, [])
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/fab.py
+++ b/nicegui/elements/fab.py
@@ -86,7 +86,7 @@ class FabAction(LabelElement, IconElement, BackgroundColorElement, DisableableEl
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the action element is clicked."""
         if has_js_action(callback):
-            self.on('click', callback, [])
+            self.on('click', callback, [])  # type: ignore[arg-type]
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self

--- a/nicegui/elements/fab.py
+++ b/nicegui/elements/fab.py
@@ -13,6 +13,7 @@ from .mixins.value_element import ValueElement
 
 
 class Fab(ValueElement, LabelElement, IconElement, BackgroundColorElement, DisableableElement):
+    LOOPBACK = False
 
     @resolve_defaults
     def __init__(self,

--- a/nicegui/elements/item.py
+++ b/nicegui/elements/item.py
@@ -33,7 +33,7 @@ class Item(DisableableElement):
         """Add a callback to be invoked when the List Item is clicked."""
         self._props['clickable'] = True  # idempotent
         if has_js_action(callback):
-            self.on('click', callback)  # type: ignore[arg-type]
+            self.on('click', callback)
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)))
         return self

--- a/nicegui/elements/item.py
+++ b/nicegui/elements/item.py
@@ -33,7 +33,7 @@ class Item(DisableableElement):
         """Add a callback to be invoked when the List Item is clicked."""
         self._props['clickable'] = True  # idempotent
         if has_js_action(callback):
-            self.on('click', callback)
+            self.on('click', callback)  # type: ignore[arg-type]
         else:
             self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)))
         return self

--- a/nicegui/elements/item.py
+++ b/nicegui/elements/item.py
@@ -1,6 +1,7 @@
 from typing_extensions import Self
 
 from ..events import ClickEventArguments, Handler, handle_event
+from ..js_action import has_js_action
 from .mixins.disableable_element import DisableableElement
 from .mixins.text_element import TextElement
 
@@ -31,7 +32,10 @@ class Item(DisableableElement):
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the List Item is clicked."""
         self._props['clickable'] = True  # idempotent
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)))
+        if has_js_action(callback):
+            self.on('click', callback)
+        else:
+            self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)))
         return self
 
 

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -7,6 +7,7 @@ from .mixins.value_element import ValueElement
 
 
 class Menu(ValueElement):
+    LOOPBACK = False
 
     @resolve_defaults
     def __init__(self, *, value: bool = DEFAULT_PROPS['model-value'] | False) -> None:

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -1,5 +1,6 @@
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..events import ClickEventArguments, Handler
+from ..js_action import js_action
 from .context_menu import ContextMenu
 from .item import Item
 from .mixins.value_element import ValueElement
@@ -26,14 +27,17 @@ class Menu(ValueElement):
                                 'The prop "touch-position" is not supported by `ui.menu`. '
                                 'Use "ui.context_menu()" instead.')
 
+    @js_action.value(True)
     def open(self) -> None:
         """Open the menu."""
         self.value = True
 
+    @js_action.value(False)
     def close(self) -> None:
         """Close the menu."""
         self.value = False
 
+    @js_action.toggle()
     def toggle(self) -> None:
         """Toggle the menu."""
         self.value = not self.value

--- a/nicegui/js_action.py
+++ b/nicegui/js_action.py
@@ -39,9 +39,8 @@ class JsAction:
 
         Used when the action was already applied on the client via JavaScript.
         """
-        from .elements.mixins.value_element import ValueElement  # pylint: disable=import-outside-toplevel
         element = self._element
-        if isinstance(element, ValueElement):
+        if hasattr(element, '_send_update_on_value_change'):
             prev = element._send_update_on_value_change  # pylint: disable=protected-access
             element._send_update_on_value_change = False  # pylint: disable=protected-access
             try:
@@ -59,7 +58,7 @@ class _JsActionDescriptor:
             raise TypeError(f'@js_action does not support async methods (got {method!r})')
         self._method = method
         self._js_handler_factory = js_handler_factory
-        functools.update_wrapper(self, method)
+        functools.update_wrapper(self, method)  # type: ignore[arg-type]
 
     def __get__(self, obj: Any, objtype: type | None = None) -> Any:
         if obj is None:

--- a/nicegui/js_action.py
+++ b/nicegui/js_action.py
@@ -88,16 +88,14 @@ class _JsActionFactory:
         """Create a decorator that sets the model-value prop to the given value."""
         js_bool = 'true' if v else 'false'
         return self(lambda el: (
-            f'(...args) => {{ elements[{el.id}].props["model-value"] = {js_bool}; '
-            f'invalidateVnodeCache([{el.id}]); mounted_app?.$forceUpdate(); emit(...args); }}'
+            f'(...args) => {{ elements[{el.id}].props["model-value"] = {js_bool}; emit(...args); }}'
         ))
 
     def toggle(self) -> Callable[[_F], _F]:
         """Create a decorator that toggles the model-value prop."""
         return self(lambda el: (
             f'(...args) => {{ const e = elements[{el.id}]; '
-            f'e.props["model-value"] = !e.props["model-value"]; '
-            f'invalidateVnodeCache([{el.id}]); mounted_app?.$forceUpdate(); emit(...args); }}'
+            f'e.props["model-value"] = !e.props["model-value"]; emit(...args); }}'
         ))
 
 

--- a/nicegui/js_action.py
+++ b/nicegui/js_action.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeGuard
 
 from .helpers import is_coroutine_function
 
 if TYPE_CHECKING:
     from .element import Element
-
-_F = TypeVar('_F', bound=Callable)
 
 
 class JsAction:
@@ -58,7 +56,14 @@ class _JsActionDescriptor:
             raise TypeError(f'@js_action does not support async methods (got {method!r})')
         self._method = method
         self._js_handler_factory = js_handler_factory
-        functools.update_wrapper(self, method)  # type: ignore[arg-type]
+        for attr in functools.WRAPPER_ASSIGNMENTS:
+            try:
+                value = getattr(method, attr)
+            except AttributeError:
+                pass
+            else:
+                setattr(self, attr, value)
+        self.__wrapped__ = method
 
     def __get__(self, obj: Any, objtype: type | None = None) -> Any:
         if obj is None:
@@ -78,19 +83,19 @@ class _JsActionFactory:
     for common model-value operations.
     """
 
-    def __call__(self, js_handler_factory: Callable[[Any], str]) -> Callable[[_F], _F]:
-        def decorator(method: _F) -> _F:
-            return _JsActionDescriptor(method, js_handler_factory)  # type: ignore[return-value]
-        return decorator  # type: ignore[return-value]
+    def __call__(self, js_handler_factory: Callable[[Any], str]) -> Callable[[Callable[..., Any]], _JsActionDescriptor]:
+        def decorator(method: Callable[..., Any]) -> _JsActionDescriptor:
+            return _JsActionDescriptor(method, js_handler_factory)
+        return decorator
 
-    def value(self, v: bool) -> Callable[[_F], _F]:
+    def value(self, v: bool) -> Callable[[Callable[..., Any]], _JsActionDescriptor]:
         """Create a decorator that sets the model-value prop to the given value."""
         js_bool = 'true' if v else 'false'
         return self(lambda el: (
             f'(...args) => {{ elements[{el.id}].props["model-value"] = {js_bool}; emit(...args); }}'
         ))
 
-    def toggle(self) -> Callable[[_F], _F]:
+    def toggle(self) -> Callable[[Callable[..., Any]], _JsActionDescriptor]:
         """Create a decorator that toggles the model-value prop."""
         return self(lambda el: (
             f'(...args) => {{ const e = elements[{el.id}]; '
@@ -101,6 +106,6 @@ class _JsActionFactory:
 js_action = _JsActionFactory()
 
 
-def has_js_action(handler: Any) -> bool:
+def has_js_action(handler: Any) -> TypeGuard[JsAction]:
     """Check if a handler is a JsAction."""
     return isinstance(handler, JsAction)

--- a/nicegui/js_action.py
+++ b/nicegui/js_action.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from .helpers import is_coroutine_function
+
+if TYPE_CHECKING:
+    from .element import Element
+
+_F = TypeVar('_F', bound=Callable)
+
+
+class JsAction:
+    """A callable action that can be optimized to run client-side via JavaScript.
+
+    When passed to event handlers like ``on_click``, the action is executed
+    on the client side via JavaScript, bypassing server-side latency. The event is
+    also sent to the server so the Python callback runs and server state stays in sync.
+    When called directly (e.g., ``dialog.open()``), it executes the Python implementation as usual.
+    """
+
+    def __init__(self, element: Element, python_fn: Callable[..., Any], js_handler: str) -> None:
+        if is_coroutine_function(python_fn):
+            raise TypeError(f'@js_action does not support async methods (got {python_fn!r})')
+        self._element = element
+        self._python_fn = python_fn
+        self._js_handler = js_handler
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._python_fn(*args, **kwargs)
+
+    def __repr__(self) -> str:
+        return f'JsAction({self._element.__class__.__name__}.{self._python_fn.__name__})'
+
+    def _call_without_loopback(self) -> Any:
+        """Call the Python function without sending a redundant update to the client.
+
+        Used when the action was already applied on the client via JavaScript.
+        """
+        from .elements.mixins.value_element import ValueElement  # pylint: disable=import-outside-toplevel
+        element = self._element
+        if isinstance(element, ValueElement):
+            prev = element._send_update_on_value_change  # pylint: disable=protected-access
+            element._send_update_on_value_change = False  # pylint: disable=protected-access
+            try:
+                return self._python_fn()
+            finally:
+                element._send_update_on_value_change = prev  # pylint: disable=protected-access
+        return self._python_fn()
+
+
+class _JsActionDescriptor:
+    """Descriptor that returns a JsAction when accessed on an element instance."""
+
+    def __init__(self, method: Callable, js_handler_factory: Callable[[Any], str]) -> None:
+        if is_coroutine_function(method):
+            raise TypeError(f'@js_action does not support async methods (got {method!r})')
+        self._method = method
+        self._js_handler_factory = js_handler_factory
+        functools.update_wrapper(self, method)
+
+    def __get__(self, obj: Any, objtype: type | None = None) -> Any:
+        if obj is None:
+            return self._method
+        bound = self._method.__get__(obj, objtype)
+        return JsAction(obj, bound, self._js_handler_factory(obj))
+
+
+class _JsActionFactory:
+    """Decorator that marks a method as having a JS action equivalent.
+
+    When the decorated method is passed as an event handler (e.g., ``on_click=dialog.open``),
+    the JS handler runs on the client side for instant response, while the Python method
+    also runs on the server to keep state in sync.
+
+    Use the convenience constructors ``js_action.value()`` and ``js_action.toggle()``
+    for common model-value operations.
+    """
+
+    def __call__(self, js_handler_factory: Callable[[Any], str]) -> Callable[[_F], _F]:
+        def decorator(method: _F) -> _F:
+            return _JsActionDescriptor(method, js_handler_factory)  # type: ignore[return-value]
+        return decorator  # type: ignore[return-value]
+
+    def value(self, v: bool) -> Callable[[_F], _F]:
+        """Create a decorator that sets the model-value prop to the given value."""
+        js_bool = 'true' if v else 'false'
+        return self(lambda el: (
+            f'(...args) => {{ elements[{el.id}].props["model-value"] = {js_bool}; '
+            f'invalidateVnodeCache([{el.id}]); emit(...args); }}'
+        ))
+
+    def toggle(self) -> Callable[[_F], _F]:
+        """Create a decorator that toggles the model-value prop."""
+        return self(lambda el: (
+            f'(...args) => {{ const e = elements[{el.id}]; '
+            f'e.props["model-value"] = !e.props["model-value"]; '
+            f'invalidateVnodeCache([{el.id}]); emit(...args); }}'
+        ))
+
+
+js_action = _JsActionFactory()
+
+
+def has_js_action(handler: Any) -> bool:
+    """Check if a handler is a JsAction."""
+    return isinstance(handler, JsAction)

--- a/nicegui/js_action.py
+++ b/nicegui/js_action.py
@@ -89,7 +89,7 @@ class _JsActionFactory:
         js_bool = 'true' if v else 'false'
         return self(lambda el: (
             f'(...args) => {{ elements[{el.id}].props["model-value"] = {js_bool}; '
-            f'invalidateVnodeCache([{el.id}]); emit(...args); }}'
+            f'invalidateVnodeCache([{el.id}]); mounted_app?.$forceUpdate(); emit(...args); }}'
         ))
 
     def toggle(self) -> Callable[[_F], _F]:
@@ -97,7 +97,7 @@ class _JsActionFactory:
         return self(lambda el: (
             f'(...args) => {{ const e = elements[{el.id}]; '
             f'e.props["model-value"] = !e.props["model-value"]; '
-            f'invalidateVnodeCache([{el.id}]); emit(...args); }}'
+            f'invalidateVnodeCache([{el.id}]); mounted_app?.$forceUpdate(); emit(...args); }}'
         ))
 
 

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -273,7 +273,7 @@ function renderRecursively(elements, id, propsContext) {
       };
       throttle(delayed_emitter, event.throttle, event.leading_events, event.trailing_events, event.listener_id);
       if (element.props["loopback"] === False && event.type == "update:modelValue") {
-        element.props["model-value"] = args;
+        element.props["model-value"] = args.length === 1 ? args[0] : args;
       }
     };
 

--- a/tests/test_js_action.py
+++ b/tests/test_js_action.py
@@ -110,7 +110,6 @@ def test_js_handler_is_installed_on_event_listener(screen: Screen):
         assert len(click_listeners) == 1
         assert click_listeners[0].js_handler is not None
         assert 'model-value' in click_listeners[0].js_handler
-        assert 'invalidateVnodeCache' in click_listeners[0].js_handler
 
     screen.open('/')
 

--- a/tests/test_js_action.py
+++ b/tests/test_js_action.py
@@ -1,3 +1,5 @@
+from selenium.webdriver import ActionChains
+
 from nicegui import ui
 from nicegui.js_action import JsAction, has_js_action, js_action
 from nicegui.testing import Screen
@@ -268,3 +270,28 @@ def test_custom_js_action_decorator(screen: Screen):
 
     screen.open('/')
     screen.should_contain('OK')
+
+
+def test_dialog_reopen_after_backdrop_close(screen: Screen):
+    """Test that a dialog can be reopened after closing via backdrop click."""
+    @ui.page('/')
+    def page():
+        with ui.dialog() as dialog, ui.card():
+            ui.label('Hello world!')
+            ui.button('Close', on_click=dialog.close)
+        ui.button('Open', on_click=dialog.open)
+
+    screen.open('/')
+    screen.should_not_contain('Hello world!')
+
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('Hello world!')
+
+    ActionChains(screen.selenium).move_by_offset(5, 5).click().perform()
+    screen.wait(0.5)
+    screen.should_not_contain('Hello world!')
+
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('Hello world!')

--- a/tests/test_js_action.py
+++ b/tests/test_js_action.py
@@ -1,0 +1,270 @@
+from nicegui import ui
+from nicegui.js_action import JsAction, has_js_action, js_action
+from nicegui.testing import Screen
+
+
+def test_dialog_open_close_with_js_action(screen: Screen):
+    """Test that on_click=dialog.open/close works with the js_action decorator."""
+    @ui.page('/')
+    def page():
+        with ui.dialog() as d, ui.card():
+            ui.label('Dialog Content')
+            ui.button('Close', on_click=d.close)
+        ui.button('Open', on_click=d.open)
+
+    screen.open('/')
+    screen.should_not_contain('Dialog Content')
+
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('Dialog Content')
+
+    screen.click('Close')
+    screen.wait(0.5)
+    screen.should_not_contain('Dialog Content')
+
+
+def test_dialog_open_close_direct_call(screen: Screen):
+    """Test that dialog.open() and dialog.close() still work as direct method calls."""
+    @ui.page('/')
+    def page():
+        with ui.dialog() as d, ui.card():
+            ui.label('Dialog Content')
+            ui.button('Close', on_click=lambda: d.close())
+        ui.button('Open', on_click=lambda: d.open())
+
+    screen.open('/')
+    screen.should_not_contain('Dialog Content')
+
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('Dialog Content')
+
+    screen.click('Close')
+    screen.wait(0.5)
+    screen.should_not_contain('Dialog Content')
+
+
+def test_menu_open_close_with_js_action(screen: Screen):
+    """Test that on_click=menu.open/close works with the js_action decorator."""
+    @ui.page('/')
+    def page():
+        with ui.button('Menu'):
+            with ui.menu() as menu:
+                ui.menu_item('Item 1')
+        ui.button('Open Menu', on_click=menu.open)
+        ui.label().bind_text_from(menu, 'value', lambda v: 'menu open' if v else 'menu closed')
+
+    screen.open('/')
+    screen.should_contain('menu closed')
+
+    screen.click('Open Menu')
+    screen.wait(0.5)
+    screen.should_contain('menu open')
+    screen.should_contain('Item 1')
+
+
+def test_fab_open_close_toggle_with_js_action(screen: Screen):
+    """Test that on_click=fab.open/close/toggle works with the js_action decorator."""
+    @ui.page('/')
+    def page():
+        with ui.fab('menu', label='FAB') as fab:
+            ui.fab_action('info', label='Action 1')
+        ui.button('Open', on_click=fab.open)
+        ui.button('Close', on_click=fab.close)
+        ui.button('Toggle', on_click=fab.toggle)
+        ui.label().bind_text_from(fab, 'value', lambda v: 'FAB open' if v else 'FAB closed')
+
+    screen.open('/')
+    screen.should_contain('FAB closed')
+
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('FAB open')
+
+    screen.click('Close')
+    screen.wait(0.5)
+    screen.should_contain('FAB closed')
+
+    screen.click('Toggle')
+    screen.wait(0.5)
+    screen.should_contain('FAB open')
+
+    screen.click('Toggle')
+    screen.wait(0.5)
+    screen.should_contain('FAB closed')
+
+
+def test_js_handler_is_installed_on_event_listener(screen: Screen):
+    """Test that passing a js_action-decorated method installs a JS handler on the listener."""
+    @ui.page('/')
+    def page():
+        with ui.dialog() as d, ui.card():
+            ui.label('Content')
+        button = ui.button('Open', on_click=d.open)
+        # Verify the event listener has a js_handler set
+        listeners = list(button._event_listeners.values())
+        click_listeners = [el for el in listeners if el.type == 'click']
+        assert len(click_listeners) == 1
+        assert click_listeners[0].js_handler is not None
+        assert 'model-value' in click_listeners[0].js_handler
+        assert 'invalidateVnodeCache' in click_listeners[0].js_handler
+
+    screen.open('/')
+
+
+def test_has_js_action_detects_decorated_methods(screen: Screen):
+    """Test that has_js_action correctly identifies decorated bound methods."""
+    @ui.page('/')
+    def page():
+        dialog = ui.dialog()
+        menu = ui.menu()
+
+        # Decorated bound methods should be detected
+        assert has_js_action(dialog.open)
+        assert has_js_action(dialog.close)
+        assert has_js_action(menu.open)
+        assert has_js_action(menu.close)
+        assert has_js_action(menu.toggle)
+
+        # Regular callables should not be detected
+        assert not has_js_action(lambda: None)
+        assert not has_js_action(print)
+
+        # JsAction instances should be detected
+        action = JsAction(dialog, lambda: None, '() => {}')
+        assert has_js_action(action)
+
+    screen.open('/')
+
+
+def test_js_action_decorator_preserves_method_behavior(screen: Screen):
+    """Test that @js_action decorator does not alter normal method behavior."""
+    @ui.page('/')
+    def page():
+        dialog = ui.dialog()
+        assert dialog.value is False
+
+        dialog.open()
+        assert dialog.value is True
+
+        dialog.close()
+        assert dialog.value is False
+
+    screen.open('/')
+
+
+def test_dialog_await_still_works(screen: Screen):
+    """Test that the dialog __await__ protocol still works with js_action methods."""
+    @ui.page('/')
+    def page():
+        with ui.dialog() as dialog, ui.card():
+            ui.button('Yes', on_click=lambda: dialog.submit('Yes'))
+
+        async def show() -> None:
+            ui.notify(f'Result: {await dialog}')
+
+        ui.button('Open', on_click=show)
+
+    screen.open('/')
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.click('Yes')
+    screen.should_contain('Result: Yes')
+
+
+def test_subclass_can_override_js_action_method(screen: Screen):
+    """Test that subclasses can override js_action-decorated methods."""
+    class MyDialog(ui.dialog):
+        def __init__(self):
+            super().__init__()
+            self.open_count = 0
+
+        def open(self):
+            self.open_count += 1
+            super().open()
+
+    @ui.page('/')
+    def page():
+        d = MyDialog()
+        with d, ui.card():
+            ui.label('Content')
+        ui.button('Open', on_click=d.open)  # bare bound method: should NOT get js_action treatment
+        ui.label().bind_text_from(d, 'open_count', lambda c: f'Opened {c} times')
+        assert not has_js_action(d.open)
+
+    screen.open('/')
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('Content')
+    screen.should_contain('Opened 1 times')
+
+
+def test_dropdown_button_open_close_toggle(screen: Screen):
+    """Test that DropdownButton open/close/toggle work with js_action."""
+    @ui.page('/')
+    def page():
+        with ui.dropdown_button('Dropdown') as dd:
+            ui.item('Option A')
+        ui.button('Open', on_click=dd.open)
+        ui.button('Close', on_click=dd.close)
+        ui.button('Toggle', on_click=dd.toggle)
+        ui.label().bind_text_from(dd, 'value', lambda v: 'DD open' if v else 'DD closed')
+
+    screen.open('/')
+    screen.should_contain('DD closed')
+
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('DD open')
+
+    screen.click('Close')
+    screen.wait(0.5)
+    screen.should_contain('DD closed')
+
+    screen.click('Toggle')
+    screen.wait(0.5)
+    screen.should_contain('DD open')
+
+
+def test_menu_item_auto_close_uses_js_action(screen: Screen):
+    """Test that MenuItem auto_close works with the js_action on Menu.close."""
+    @ui.page('/')
+    def page():
+        with ui.button('Open'):
+            with ui.menu() as menu:
+                ui.menu_item('Click me', on_click=lambda: ui.notify('clicked'))
+        ui.label().bind_text_from(menu, 'value', lambda v: 'menu open' if v else 'menu closed')
+
+    screen.open('/')
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('menu open')
+
+    screen.click('Click me')
+    screen.wait(0.5)
+    screen.should_contain('clicked')
+    screen.should_contain('menu closed')
+
+
+def test_custom_js_action_decorator(screen: Screen):
+    """Test that users can create their own js_action-decorated methods."""
+    class MyElement(ui.element):
+        def __init__(self):
+            super().__init__('div')
+            self._count = 0
+
+        @js_action(lambda self: '(...args) => { emit(...args); }')
+        def increment(self):
+            self._count += 1
+
+    @ui.page('/')
+    def page():
+        el = MyElement()
+        assert has_js_action(el.increment)
+        el.increment()
+        assert el._count == 1
+        ui.label('OK')
+
+    screen.open('/')
+    screen.should_contain('OK')


### PR DESCRIPTION
*Opened by Claude Code on Evan's behalf.*

Continuation of zauberzeug/nicegui#5843 (`@js_action` decorator for client-side open/close/toggle optimization), moved to the fork because:

1. The performance-aware crowd this optimizes for is not the majority of NiceGUI users, so it doesn't justify upstream API surface right now.
2. The original motivating signal is gone: nicegui.io's INP scores recovered in Google Search Console after the docs revamp (cause not fully understood, but the empirical result stands).

Kept here for the day the trade-off flips (e.g. INP regresses again, or upstream grows a client-side-actions story). Branch is `jsaction` as closed upstream; merge conflicts with upstream main are unresolved as of moving.
