### PR TITLE
[brick] Make the nicegui package import lazy via PEP 562 (#5684)

### DIFF
--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -1,13 +1,37 @@
-from . import binding, elements, html, run, storage, ui
-from .api_router import APIRouter
-from .app.app import App
-from .client import Client
-from .context import context
-from .element_filter import ElementFilter
-from .event import Event
-from .nicegui import app
-from .page_arguments import PageArguments
-from .version import __version__
+import importlib
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+_LAZY_IMPORTS = {
+    'APIRouter': ('.api_router', 'APIRouter'),
+    'App': ('.app.app', 'App'),
+    'Client': ('.client', 'Client'),
+    'ElementFilter': ('.element_filter', 'ElementFilter'),
+    'Event': ('.event', 'Event'),
+    'PageArguments': ('.page_arguments', 'PageArguments'),
+    '__version__': ('.version', '__version__'),
+    'app': ('.nicegui', 'app'),
+    'binding': ('.binding', ''),
+    'context': ('.context', 'context'),
+    'elements': ('.elements', ''),
+    'html': ('.html', ''),
+    'run': ('.run', ''),
+    'storage': ('.storage', ''),
+    'ui': ('.ui', ''),
+}
+
+if TYPE_CHECKING:
+    from . import binding, elements, html, run, storage, ui
+    from .api_router import APIRouter
+    from .app.app import App
+    from .client import Client
+    from .context import context
+    from .element_filter import ElementFilter
+    from .event import Event
+    from .nicegui import app
+    from .page_arguments import PageArguments
+    from .version import __version__
 
 __all__ = [
     'APIRouter',
@@ -26,3 +50,65 @@ __all__ = [
     'storage',
     'ui',
 ]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def __getattr__(name: str) -> object:
+    if name not in _LAZY_IMPORTS:
+        raise AttributeError(f"module 'nicegui' has no attribute {name!r}")
+    module_path, attr_name = _LAZY_IMPORTS[name]
+    module = importlib.import_module(module_path, package='nicegui')
+    value = getattr(module, attr_name) if attr_name else module
+    setattr(sys.modules[__name__], name, value)
+    return value
+
+
+class _PackageModule(ModuleType):
+    """Class for the nicegui package module itself.
+
+    The attributes `app` and `context` collide with the submodules `nicegui.app` and `nicegui.context`:
+    whenever the import machinery loads those submodules, it binds them as package attributes, shadowing
+    the `App` and `Context` instances which `__getattr__` would provide. (The eager package init used to win
+    this race by assignment order.) Data descriptors on the module's class take precedence over instance
+    attributes, so these properties always return the instances.
+    """
+
+    @property
+    def app(self):
+        """The global ``App`` instance (shadows the ``nicegui.app`` subpackage; see class docstring)."""
+        if '_app_override' in self.__dict__:
+            return self.__dict__['_app_override']
+        from .nicegui import app  # pylint: disable=import-outside-toplevel,redefined-outer-name
+        return app
+
+    @app.setter
+    def app(self, value) -> None:
+        if not isinstance(value, ModuleType):  # silently absorb the import machinery's submodule binding only
+            self.__dict__['_app_override'] = value  # support deliberate assignment, e.g. mock.patch
+
+    @app.deleter
+    def app(self) -> None:
+        self.__dict__.pop('_app_override', None)
+
+    @property
+    def context(self):
+        """The global ``Context`` instance (shadows the ``nicegui.context`` submodule; see class docstring)."""
+        if '_context_override' in self.__dict__:
+            return self.__dict__['_context_override']
+        from .context import context  # pylint: disable=import-outside-toplevel,redefined-outer-name
+        return context
+
+    @context.setter
+    def context(self, value) -> None:
+        if not isinstance(value, ModuleType):  # silently absorb the import machinery's submodule binding only
+            self.__dict__['_context_override'] = value  # support deliberate assignment, e.g. mock.patch
+
+    @context.deleter
+    def context(self) -> None:
+        self.__dict__.pop('_context_override', None)
+
+
+sys.modules[__name__].__class__ = _PackageModule

--- a/nicegui/core.py
+++ b/nicegui/core.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from socketio import AsyncServer
-
 if TYPE_CHECKING:
+    from socketio import AsyncServer
+
     from .air import Air
     from .app import App
     from .client import Client
@@ -18,6 +19,19 @@ air: Air | None = None
 root: Callable | None = None
 script_mode: bool = False
 script_client: Client | None = None
+
+
+def __getattr__(name: str) -> object:
+    if name in {'app', 'sio'}:
+        # lazily build the App and AsyncServer on first access by importing the nicegui module which assigns them
+        module = importlib.import_module('.nicegui', package='nicegui')
+        if name in globals():
+            return globals()[name]
+        # in worker stub mode the module above is a no-op stub which does not assign anything; fall through to
+        # its attribute access which yields a no-op object (e.g. a falsy `core.app.is_stopping` in `run._run`);
+        # a genuine circular import raises AttributeError with Python's standard "partially initialized" hint
+        return getattr(module, name)
+    raise AttributeError(f"module 'nicegui.core' has no attribute {name!r}")
 
 
 def is_loop_running() -> bool:

--- a/nicegui/json/__init__.py
+++ b/nicegui/json/__init__.py
@@ -8,10 +8,15 @@ in socketio.AsyncServer, which expects a module as parameter
 to override Python's default json module.
 """
 
+from typing import TYPE_CHECKING
+
 try:
-    from .orjson_wrapper import NiceGUIJSONResponse, dumps, loads
+    from .orjson_wrapper import dumps, loads
 except ImportError:
-    from .builtin_wrapper import NiceGUIJSONResponse, dumps, loads  # type: ignore
+    from .builtin_wrapper import dumps, loads  # type: ignore
+
+if TYPE_CHECKING:
+    from .response import NiceGUIJSONResponse
 
 
 __all__ = [
@@ -19,3 +24,11 @@ __all__ = [
     'dumps',
     'loads',
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == 'NiceGUIJSONResponse':  # deferred so that `import nicegui.json` does not pull in FastAPI
+        from .response import NiceGUIJSONResponse  # pylint: disable=import-outside-toplevel
+        globals()[name] = NiceGUIJSONResponse
+        return NiceGUIJSONResponse
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/nicegui/json/builtin_wrapper.py
+++ b/nicegui/json/builtin_wrapper.py
@@ -3,8 +3,6 @@ import json
 from datetime import date, datetime
 from typing import Any
 
-from fastapi.responses import JSONResponse
-
 try:
     HAS_NUMPY = importlib.util.find_spec('numpy') is not None
 except (ModuleNotFoundError, ValueError):
@@ -37,13 +35,6 @@ def loads(value: str) -> Any:
     Uses Python's default json module internally.
     """
     return json.loads(value)
-
-
-class NiceGUIJSONResponse(JSONResponse):
-    """FastAPI response class to support our custom json serializer implementation."""
-
-    def render(self, content: Any) -> bytes:
-        return dumps(content).encode('utf-8')
 
 
 class NumpyJsonEncoder(json.JSONEncoder):

--- a/nicegui/json/orjson_wrapper.py
+++ b/nicegui/json/orjson_wrapper.py
@@ -4,7 +4,6 @@ from typing import Any
 
 # pylint: disable=no-member
 import orjson
-from fastapi.responses import JSONResponse
 
 try:
     HAS_NUMPY = importlib.util.find_spec('numpy') is not None
@@ -60,13 +59,3 @@ def _orjson_converter(obj):
     if isinstance(obj, Decimal):
         return float(obj)
     raise TypeError(f'Object of type {obj.__class__.__name__} is not JSON serializable')
-
-
-class NiceGUIJSONResponse(JSONResponse):
-    """FastAPI response class to support our custom json serializer implementation.
-
-    Uses package `orjson` internally.
-    """
-
-    def render(self, content: Any) -> bytes:
-        return orjson.dumps(content, option=ORJSON_OPTS, default=_orjson_converter)

--- a/nicegui/json/response.py
+++ b/nicegui/json/response.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+try:
+    import orjson
+
+    from .orjson_wrapper import ORJSON_OPTS, _orjson_converter
+
+    def _render(content: Any) -> bytes:
+        return orjson.dumps(content, option=ORJSON_OPTS, default=_orjson_converter)  # pylint: disable=no-member
+except ImportError:
+    from . import dumps
+
+    def _render(content: Any) -> bytes:
+        return dumps(content).encode('utf-8')
+
+
+class NiceGUIJSONResponse(JSONResponse):
+    """FastAPI response class to support our custom json serializer implementation."""
+
+    def render(self, content: Any) -> bytes:
+        return _render(content)

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,13 +1,71 @@
 import subprocess
+import sys
 from textwrap import dedent
 
 import pytest
 
+import nicegui
 from nicegui import ui
 
 
 def test_lazy_imports_match_all():
     assert set(ui._LAZY_IMPORTS) == set(ui.__all__)  # pylint: disable=protected-access
+
+
+def test_package_lazy_imports_match_all():
+    assert set(nicegui._LAZY_IMPORTS) == set(nicegui.__all__)  # pylint: disable=protected-access
+
+
+def test_package_all_names_resolve():
+    for name in nicegui.__all__:
+        obj = getattr(nicegui, name)
+        assert obj is not None, f'nicegui.{name} should not be None'
+
+
+def test_package_app_is_the_app_instance():
+    from nicegui.app.app import App
+    assert isinstance(nicegui.app, App), 'nicegui.app must be the App instance, not the nicegui.app subpackage'
+
+
+def test_package_app_and_context_can_be_monkeypatched():
+    from unittest import mock
+    original = nicegui.app
+    with mock.patch.object(nicegui, 'app') as fake:
+        assert nicegui.app is fake
+    assert nicegui.app is original
+
+
+def test_lazy_objects_win_over_submodule_shadowing():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import nicegui.context  # import submodules FIRST so the import machinery sets the package attributes...
+        import nicegui.nicegui
+        from nicegui import app, context  # ...which must NOT shadow the actual objects
+        assert type(context).__name__ == 'Context', f'expected Context instance, got {type(context)}'
+        assert type(app).__name__ == 'App', f'expected App instance, got {type(app)}'
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_package_import_does_not_import_web_framework():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import sys
+        import nicegui
+        heavy = {'fastapi', 'starlette', 'socketio', 'engineio', 'uvicorn', 'matplotlib', 'httpx'}
+        loaded = heavy & set(sys.modules)
+        sys.exit(f'unexpectedly imported: {loaded}' if loaded else 0)
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ui_import_does_not_import_web_framework():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import sys
+        from nicegui import ui
+        heavy = {'fastapi', 'starlette', 'socketio', 'engineio', 'uvicorn', 'matplotlib', 'httpx'}
+        loaded = heavy & set(sys.modules)
+        sys.exit(f'unexpectedly imported: {loaded}' if loaded else 0)
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_all_names_resolve():


### PR DESCRIPTION
*🧱 Brick PR (拋磚引玉, [chengyu-throw-brick-attract-jade](https://github.com/evnchn/chengyu-skill-catalog)) — deliberately rough first pass on the evnchn fork for review and selection; NOT aimed at upstream in this state. Drafted overnight by Claude Code (Fable 5) under Evan's standing instructions; all measurements reproduced locally; adversarially code-reviewed by a subagent (3 findings fixed, see below).*

## Motivation

#5684 remains open after #5303: `nicegui/__init__.py` is still fully eager, so `from nicegui import ui` (the universal idiom, re-executed in every spawned subprocess) still pays FastAPI + socketio/engineio/aiohttp/redis + `App()` construction. Falko post-#5303: *"the situation hasn't improved fundamentally."*

This PR extends the proven PEP 562 `_LAZY_IMPORTS` pattern from `ui.py` one level up to the package `__init__`, and removes the two heavy transitive imports that made even the light modules expensive (`nicegui.json` → `fastapi.responses`; `nicegui.core` → `socketio`).

## Implementation

- `nicegui/__init__.py`: PEP 562 `__getattr__` + `_LAZY_IMPORTS` + `TYPE_CHECKING` block, mirroring `ui.py`. `__version__` also lazy (`importlib.metadata` alone was 79 ms).
- **Submodule-shadowing collision** (the lazy_loader issue-#32 class): `app` and `context` are both lazy attributes AND submodule names; whenever the import machinery loads `nicegui.app`/`nicegui.context`, it binds the *module* as a package attribute, shadowing the instances (eager init used to win this race by assignment order — found the hard way via `test_storage.py` tab-storage failures). Solved with the module-`__class__` swap: `_PackageModule` defines `app`/`context` as data descriptors, which always beat instance attributes. Setters absorb the machinery's module binding but store deliberate assignments in an override slot, and deleters exist — so `mock.patch.object(nicegui, 'app', ...)` works (subagent review caught the crash-on-restore).
- `nicegui/core.py`: `socketio.AsyncServer` import → `TYPE_CHECKING` (annotation-only). Module `__getattr__` materializes `core.app`/`core.sio` on first access by importing `nicegui.nicegui` — preserving "app exists when touched" semantics (`context.py` touches `core.app` on every element creation). If the module didn't assign them (worker-stub mode in the companion PR, or a genuine circular import), it falls through to module attribute access, which yields a no-op stub or Python's standard "partially initialized" error respectively.
- `nicegui/json/`: `NiceGUIJSONResponse` moved to new `json/response.py` behind a module `__getattr__`, so `nicegui.json` (needed by `element.py`) no longer imports FastAPI. orjson/builtin fallback preserved in all four orjson×fastapi presence quadrants.
- `tests/test_lazy_imports.py`: +7 tests — package dict↔`__all__` sync, all names resolve, `nicegui.app`/`nicegui.context` are instances even when submodules are imported first, mock.patch round-trip, and `import nicegui` / `from nicegui import ui` import none of fastapi/starlette/socketio/engineio/uvicorn/matplotlib/httpx.

## Benchmarks (M4 MacBook Air, Python 3.12.11, median of 5 fresh interpreters, idle machine)

| #5684 scenario | main @ 5e30684 | this PR |
|---|---|---|
| `import nicegui` | 223.3 ms | **3.6 ms** |
| `from nicegui import ui` | 225.1 ms | **30.7 ms** |
| `from nicegui import ui, app` (full materialization) | 227.9 ms | 216.7 ms (unchanged, expected) |
| S2-proxy: spawn child round-trip, main has `from nicegui import ui` | 281.0 ms | **50.7 ms** |
| S3: `Manager()` | 245.0 ms | **47.2 ms** |
| S4: first 10× `cpu_bound` (steady ≈1.0 s) | 1.50 s | 1.46 s |

S4 barely moves because workers re-import the user's main module which materializes `app`; that is the companion worker-stubs PR's job. These two PRs compose (this one makes the real modules cheap enough that the stub PR can keep `run`/`core`/`helpers` real, healing #4471's Ctrl-C and pytest wounds).

## Known rough edges (deliberately left for review)

1. **Deferred-exception relocation** (the #1 documented lazy-import footgun per PEP 690's rejection record): a broken transitive dep now surfaces at first `nicegui.X` touch instead of at import. No `NICEGUI_EAGER_IMPORT` escape hatch yet (lazy_loader ships one; cheap to add).
2. `from nicegui.json.orjson_wrapper import NiceGUIJSONResponse` (private path) no longer works — moved to `json/response.py`. Repo+docs grep shows no users.
3. REPL behavior (`python -i`, Jupyter) untested — SciPy's lazy loader died on exactly this (SPEC-1 background).
4. `vars(nicegui)['app']` no longer exists (descriptor-only) — observable but obscure difference.
5. Benchmarks are macOS/arm64 only; Windows (spawn-default, the loudest reporter population) unmeasured.
6. Full suite green locally except 8 pre-existing `test_dark_mode` failures that reproduce identically on untouched main (host macOS in dark mode; `dark=None` follows OS).

## Choice points for Evan

- [ ] Ship `NICEGUI_EAGER_IMPORT=1` escape hatch in this PR or follow-up?
- [ ] Keep `__version__` lazy (saves 79 ms) or revert to eager (REPL friendliness)?
- [ ] The `_PackageModule` class-swap is the load-bearing novelty vs #5303's plain `__getattr__` — comfortable with it, or prefer renaming a submodule to dodge the collision (breaking)?

## Progress

- [x] Full pytest suite (947 tests) green locally modulo pre-existing dark-mode env failures
- [x] pre-commit / mypy (243 files) / pylint 10.00 clean
- [x] Subagent adversarial code review; Critical+Important findings fixed (mock.patch deleter crash, stub-mode core.app, vacuous test assertion)
- [ ] Windows benchmark
- [ ] REPL smoke
