### PR TITLE
[brick] Fix #5684 subprocess re-import: lazy package import + worker stubs

### DIFF
--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -1,7 +1,14 @@
 import importlib
+import os
 import sys
 from types import ModuleType
 from typing import TYPE_CHECKING
+
+if os.environ.get('NICEGUI_WORKER_STUBS') == '1':
+    import multiprocessing  # cheap here: already imported by the spawn bootstrap in any real worker
+    if multiprocessing.current_process().name != 'MainProcess':
+        from . import _worker_stubs
+        _worker_stubs.install()
 
 _LAZY_IMPORTS = {
     'APIRouter': ('.api_router', 'APIRouter'),

--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -1,13 +1,37 @@
-from . import binding, elements, html, run, storage, ui
-from .api_router import APIRouter
-from .app.app import App
-from .client import Client
-from .context import context
-from .element_filter import ElementFilter
-from .event import Event
-from .nicegui import app
-from .page_arguments import PageArguments
-from .version import __version__
+import importlib
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+_LAZY_IMPORTS = {
+    'APIRouter': ('.api_router', 'APIRouter'),
+    'App': ('.app.app', 'App'),
+    'Client': ('.client', 'Client'),
+    'ElementFilter': ('.element_filter', 'ElementFilter'),
+    'Event': ('.event', 'Event'),
+    'PageArguments': ('.page_arguments', 'PageArguments'),
+    '__version__': ('.version', '__version__'),
+    'app': ('.nicegui', 'app'),
+    'binding': ('.binding', ''),
+    'context': ('.context', 'context'),
+    'elements': ('.elements', ''),
+    'html': ('.html', ''),
+    'run': ('.run', ''),
+    'storage': ('.storage', ''),
+    'ui': ('.ui', ''),
+}
+
+if TYPE_CHECKING:
+    from . import binding, elements, html, run, storage, ui
+    from .api_router import APIRouter
+    from .app.app import App
+    from .client import Client
+    from .context import context
+    from .element_filter import ElementFilter
+    from .event import Event
+    from .nicegui import app
+    from .page_arguments import PageArguments
+    from .version import __version__
 
 __all__ = [
     'APIRouter',
@@ -26,3 +50,65 @@ __all__ = [
     'storage',
     'ui',
 ]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def __getattr__(name: str) -> object:
+    if name not in _LAZY_IMPORTS:
+        raise AttributeError(f"module 'nicegui' has no attribute {name!r}")
+    module_path, attr_name = _LAZY_IMPORTS[name]
+    module = importlib.import_module(module_path, package='nicegui')
+    value = getattr(module, attr_name) if attr_name else module
+    setattr(sys.modules[__name__], name, value)
+    return value
+
+
+class _PackageModule(ModuleType):
+    """Class for the nicegui package module itself.
+
+    The attributes `app` and `context` collide with the submodules `nicegui.app` and `nicegui.context`:
+    whenever the import machinery loads those submodules, it binds them as package attributes, shadowing
+    the `App` and `Context` instances which `__getattr__` would provide. (The eager package init used to win
+    this race by assignment order.) Data descriptors on the module's class take precedence over instance
+    attributes, so these properties always return the instances.
+    """
+
+    @property
+    def app(self):
+        """The global ``App`` instance (shadows the ``nicegui.app`` subpackage; see class docstring)."""
+        if '_app_override' in self.__dict__:
+            return self.__dict__['_app_override']
+        from .nicegui import app  # pylint: disable=import-outside-toplevel,redefined-outer-name
+        return app
+
+    @app.setter
+    def app(self, value) -> None:
+        if not isinstance(value, ModuleType):  # silently absorb the import machinery's submodule binding only
+            self.__dict__['_app_override'] = value  # support deliberate assignment, e.g. mock.patch
+
+    @app.deleter
+    def app(self) -> None:
+        self.__dict__.pop('_app_override', None)
+
+    @property
+    def context(self):
+        """The global ``Context`` instance (shadows the ``nicegui.context`` submodule; see class docstring)."""
+        if '_context_override' in self.__dict__:
+            return self.__dict__['_context_override']
+        from .context import context  # pylint: disable=import-outside-toplevel,redefined-outer-name
+        return context
+
+    @context.setter
+    def context(self, value) -> None:
+        if not isinstance(value, ModuleType):  # silently absorb the import machinery's submodule binding only
+            self.__dict__['_context_override'] = value  # support deliberate assignment, e.g. mock.patch
+
+    @context.deleter
+    def context(self) -> None:
+        self.__dict__.pop('_context_override', None)
+
+
+sys.modules[__name__].__class__ = _PackageModule

--- a/nicegui/_worker_stubs.py
+++ b/nicegui/_worker_stubs.py
@@ -1,0 +1,93 @@
+"""Stub modules for worker subprocesses (see https://github.com/zauberzeug/nicegui/issues/5684).
+
+When a NiceGUI app spawns worker subprocesses (``run.cpu_bound``, ``multiprocessing.Pool``, ``Manager()``, ...),
+each worker re-imports the user's main module and thereby the nicegui package.
+Workers don't serve UI, so all UI-related modules are replaced with no-op stubs which makes the re-import
+practically free and turns module-level UI code (``ui.label(...)``, ``ui.run(...)``) into harmless no-ops.
+
+Modules listed in ``REAL_MODULES`` are NOT stubbed:
+
+- ``run`` must be real because unpickling a ``run.cpu_bound`` payload imports it in the worker
+- ``core`` and ``helpers`` are needed by ``run`` (and are cheap to import)
+- ``native`` must be real because the native-mode window subprocess executes its entry point
+- the rest are cheap leaf modules without UI side effects
+
+Known limitations (by design — workers should not consume UI state):
+
+- worker code that READS values from stubbed modules gets ``WHATEVER`` objects: comparisons are ``False``,
+  truthiness is ``False``, iteration is empty — conditions silently take the negative branch
+- operations that are not stubbed (``len()``, ``int()``, ``+`` with a real left operand, format specs)
+  raise loudly, which is preferable to silent corruption
+- ``import nicegui.elements.button``-style submodule imports fail in stub mode (``from nicegui import ui`` works)
+- ``nicegui.testing`` is stubbed, which is fine: the pytest plugin loads in pytest's main process, never in workers
+- ``fork``-started children (Linux <= 3.13 default) inherit the parent's real modules, so stubs never engage
+  there — no benefit, but also no cost, since fork does not re-import anything
+"""
+import os
+import sys
+from types import ModuleType
+from typing import Literal
+
+REAL_MODULES = {
+    'core',
+    'helpers',
+    'json',
+    'logging',
+    'native',
+    'optional_features',
+    'run',
+    'version',
+}
+
+
+class Whatever:
+    """A universal no-op object: every operation yields the no-op singleton ``WHATEVER``."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass  # accept any arguments so that user classes subclassing a stub (via __mro_entries__) can instantiate
+
+    def __getattr__(self, name: str) -> 'Whatever':
+        return WHATEVER
+
+    def __call__(self, *args, **kwargs) -> 'Whatever':
+        return WHATEVER
+
+    def __mro_entries__(self, *args, **kwargs) -> tuple:  # pylint: disable=unused-argument
+        return (Whatever,)  # so module-level `class X(ui.element)` survives class creation
+
+    def __enter__(self) -> 'Whatever':
+        return WHATEVER  # so module-level `with ui.row():` no-ops (e.g. examples/menu_and_tabs)
+
+    def __exit__(self, *args) -> Literal[False]:
+        return False
+
+    def __getitem__(self, item) -> 'Whatever':
+        return WHATEVER  # e.g. generic subscription like Handler[X] in annotations evaluated at class definition
+
+    def __repr__(self) -> str:
+        return '<nicegui worker stub>'
+
+
+WHATEVER = Whatever()
+
+
+class WhateverModule(ModuleType):
+    """A module whose every attribute is the ``WHATEVER`` no-op object."""
+
+    def __getattr__(self, name: str) -> Whatever:
+        return WHATEVER
+
+
+def install() -> None:
+    """Pre-fill ``sys.modules`` with stubs for all non-essential top-level nicegui modules."""
+    package_dir = os.path.dirname(__file__)
+    for entry in os.scandir(package_dir):
+        if entry.name.endswith('.py'):
+            name = entry.name[:-3]
+        elif entry.is_dir() and os.path.isfile(os.path.join(entry.path, '__init__.py')):
+            name = entry.name
+        else:
+            continue
+        if name.startswith('_') or name in REAL_MODULES:
+            continue
+        sys.modules[f'nicegui.{name}'] = WhateverModule(f'nicegui.{name}')

--- a/nicegui/core.py
+++ b/nicegui/core.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from socketio import AsyncServer
-
 if TYPE_CHECKING:
+    from socketio import AsyncServer
+
     from .air import Air
     from .app import App
     from .client import Client
@@ -18,6 +19,19 @@ air: Air | None = None
 root: Callable | None = None
 script_mode: bool = False
 script_client: Client | None = None
+
+
+def __getattr__(name: str) -> object:
+    if name in {'app', 'sio'}:
+        # lazily build the App and AsyncServer on first access by importing the nicegui module which assigns them
+        module = importlib.import_module('.nicegui', package='nicegui')
+        if name in globals():
+            return globals()[name]
+        # in worker stub mode the module above is a no-op stub which does not assign anything; fall through to
+        # its attribute access which yields a no-op object (e.g. a falsy `core.app.is_stopping` in `run._run`);
+        # a genuine circular import raises AttributeError with Python's standard "partially initialized" hint
+        return getattr(module, name)
+    raise AttributeError(f"module 'nicegui.core' has no attribute {name!r}")
 
 
 def is_loop_running() -> bool:

--- a/nicegui/json/__init__.py
+++ b/nicegui/json/__init__.py
@@ -8,10 +8,15 @@ in socketio.AsyncServer, which expects a module as parameter
 to override Python's default json module.
 """
 
+from typing import TYPE_CHECKING
+
 try:
-    from .orjson_wrapper import NiceGUIJSONResponse, dumps, loads
+    from .orjson_wrapper import dumps, loads
 except ImportError:
-    from .builtin_wrapper import NiceGUIJSONResponse, dumps, loads  # type: ignore
+    from .builtin_wrapper import dumps, loads  # type: ignore
+
+if TYPE_CHECKING:
+    from .response import NiceGUIJSONResponse
 
 
 __all__ = [
@@ -19,3 +24,11 @@ __all__ = [
     'dumps',
     'loads',
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == 'NiceGUIJSONResponse':  # deferred so that `import nicegui.json` does not pull in FastAPI
+        from .response import NiceGUIJSONResponse  # pylint: disable=import-outside-toplevel
+        globals()[name] = NiceGUIJSONResponse
+        return NiceGUIJSONResponse
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/nicegui/json/builtin_wrapper.py
+++ b/nicegui/json/builtin_wrapper.py
@@ -3,8 +3,6 @@ import json
 from datetime import date, datetime
 from typing import Any
 
-from fastapi.responses import JSONResponse
-
 try:
     HAS_NUMPY = importlib.util.find_spec('numpy') is not None
 except (ModuleNotFoundError, ValueError):
@@ -37,13 +35,6 @@ def loads(value: str) -> Any:
     Uses Python's default json module internally.
     """
     return json.loads(value)
-
-
-class NiceGUIJSONResponse(JSONResponse):
-    """FastAPI response class to support our custom json serializer implementation."""
-
-    def render(self, content: Any) -> bytes:
-        return dumps(content).encode('utf-8')
 
 
 class NumpyJsonEncoder(json.JSONEncoder):

--- a/nicegui/json/orjson_wrapper.py
+++ b/nicegui/json/orjson_wrapper.py
@@ -4,7 +4,6 @@ from typing import Any
 
 # pylint: disable=no-member
 import orjson
-from fastapi.responses import JSONResponse
 
 try:
     HAS_NUMPY = importlib.util.find_spec('numpy') is not None
@@ -60,13 +59,3 @@ def _orjson_converter(obj):
     if isinstance(obj, Decimal):
         return float(obj)
     raise TypeError(f'Object of type {obj.__class__.__name__} is not JSON serializable')
-
-
-class NiceGUIJSONResponse(JSONResponse):
-    """FastAPI response class to support our custom json serializer implementation.
-
-    Uses package `orjson` internally.
-    """
-
-    def render(self, content: Any) -> bytes:
-        return orjson.dumps(content, option=ORJSON_OPTS, default=_orjson_converter)

--- a/nicegui/json/response.py
+++ b/nicegui/json/response.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+try:
+    import orjson
+
+    from .orjson_wrapper import ORJSON_OPTS, _orjson_converter
+
+    def _render(content: Any) -> bytes:
+        return orjson.dumps(content, option=ORJSON_OPTS, default=_orjson_converter)  # pylint: disable=no-member
+except ImportError:
+    from . import dumps
+
+    def _render(content: Any) -> bytes:
+        return dumps(content).encode('utf-8')
+
+
+class NiceGUIJSONResponse(JSONResponse):
+    """FastAPI response class to support our custom json serializer implementation."""
+
+    def render(self, content: Any) -> bytes:
+        return _render(content)

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -218,6 +218,9 @@ def run(root: Callable | None = None, *,
         core.air = Air('' if on_air is True else on_air)
 
     if multiprocessing.current_process().name != 'MainProcess':
+        # this is the reload server child (or a worker re-running user code): mark the environment so that
+        # subprocesses spawned from here on get worker stubs (see _worker_stubs.py and #5684)
+        os.environ['NICEGUI_WORKER_STUBS'] = '1'
         return
 
     is_repl = bool(getattr(sys, 'ps1', sys.flags.interactive))
@@ -266,6 +269,15 @@ def run(root: Callable | None = None, *,
     os.environ['NICEGUI_PORT'] = str(port)
     os.environ['NICEGUI_PROTOCOL'] = protocol
 
+    # From here on, child processes (cpu_bound workers, user-created processes, ...) are workers which should
+    # import nicegui as cheap no-op stubs (see _worker_stubs.py and #5684). The native webview window child is
+    # spawned above WITHOUT this marker because it needs the real package (it reads core.app.native.*), and the
+    # marker is removed again below before the reload supervisor spawns the server child for the same reason.
+    # Under pytest the marker is not set at all: the Screen fixture calls ui.run() in the test process, and
+    # leaking the marker into the test session would make the behavior of later tests order-dependent.
+    if not helpers.is_pytest():
+        os.environ['NICEGUI_WORKER_STUBS'] = '1'
+
     if show:
         helpers.schedule_browser(protocol, host, port, show if isinstance(show, str) else '/')
 
@@ -301,9 +313,11 @@ def run(root: Callable | None = None, *,
         sys.exit(1)
 
     if config.should_reload:
+        os.environ.pop('NICEGUI_WORKER_STUBS', None)  # the spawned server child needs the real nicegui package
         sock = config.bind_socket()
         ChangeReload(config, target=Server.instance.run, sockets=[sock]).run()
     elif config.workers > 1:
+        os.environ.pop('NICEGUI_WORKER_STUBS', None)  # spawned server workers need the real nicegui package
         sock = config.bind_socket()
         Multiprocess(config, target=Server.instance.run, sockets=[sock]).run()
     else:

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,13 +1,71 @@
 import subprocess
+import sys
 from textwrap import dedent
 
 import pytest
 
+import nicegui
 from nicegui import ui
 
 
 def test_lazy_imports_match_all():
     assert set(ui._LAZY_IMPORTS) == set(ui.__all__)  # pylint: disable=protected-access
+
+
+def test_package_lazy_imports_match_all():
+    assert set(nicegui._LAZY_IMPORTS) == set(nicegui.__all__)  # pylint: disable=protected-access
+
+
+def test_package_all_names_resolve():
+    for name in nicegui.__all__:
+        obj = getattr(nicegui, name)
+        assert obj is not None, f'nicegui.{name} should not be None'
+
+
+def test_package_app_is_the_app_instance():
+    from nicegui.app.app import App
+    assert isinstance(nicegui.app, App), 'nicegui.app must be the App instance, not the nicegui.app subpackage'
+
+
+def test_package_app_and_context_can_be_monkeypatched():
+    from unittest import mock
+    original = nicegui.app
+    with mock.patch.object(nicegui, 'app') as fake:
+        assert nicegui.app is fake
+    assert nicegui.app is original
+
+
+def test_lazy_objects_win_over_submodule_shadowing():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import nicegui.context  # import submodules FIRST so the import machinery sets the package attributes...
+        import nicegui.nicegui
+        from nicegui import app, context  # ...which must NOT shadow the actual objects
+        assert type(context).__name__ == 'Context', f'expected Context instance, got {type(context)}'
+        assert type(app).__name__ == 'App', f'expected App instance, got {type(app)}'
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_package_import_does_not_import_web_framework():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import sys
+        import nicegui
+        heavy = {'fastapi', 'starlette', 'socketio', 'engineio', 'uvicorn', 'matplotlib', 'httpx'}
+        loaded = heavy & set(sys.modules)
+        sys.exit(f'unexpectedly imported: {loaded}' if loaded else 0)
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ui_import_does_not_import_web_framework():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import sys
+        from nicegui import ui
+        heavy = {'fastapi', 'starlette', 'socketio', 'engineio', 'uvicorn', 'matplotlib', 'httpx'}
+        loaded = heavy & set(sys.modules)
+        sys.exit(f'unexpectedly imported: {loaded}' if loaded else 0)
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_all_names_resolve():

--- a/tests/test_worker_stubs.py
+++ b/tests/test_worker_stubs.py
@@ -1,0 +1,123 @@
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+EXAMPLES = Path(__file__).resolve().parent.parent / 'examples'
+
+WORKER_CODE = dedent('''\
+    import os, sys, time
+    os.environ['NICEGUI_WORKER_STUBS'] = '1'
+    import multiprocessing as mp
+
+    def child(queue):
+        t0 = time.perf_counter()
+        import nicegui
+        from nicegui import ui, app
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        from nicegui import run  # what unpickling a cpu_bound payload triggers; must be the REAL module
+        label = ui.label('hello')          # must be a no-op
+        with ui.row():                     # context manager must work
+            ui.button('x')
+        ui.run()                           # must be a no-op
+        queue.put({
+            'elapsed_ms': elapsed_ms,
+            'ui_is_stub': type(sys.modules['nicegui.ui']).__name__ == 'WhateverModule',
+            'run_is_real': type(sys.modules['nicegui.run']).__name__ != 'WhateverModule',
+            'cpu_bound_callable': callable(run.cpu_bound) and run.cpu_bound.__name__ == 'cpu_bound',
+            'fastapi_loaded': 'fastapi' in sys.modules,
+        })
+
+    if __name__ == '__main__':
+        ctx = mp.get_context('spawn')
+        q = ctx.Queue()
+        p = ctx.Process(target=child, args=(q,))
+        p.start()
+        result = q.get(timeout=30)
+        p.join()
+        print(result)
+        assert result['ui_is_stub'], 'ui must be stubbed in worker'
+        assert result['run_is_real'], 'run must be the real module in worker'
+        assert result['cpu_bound_callable'], 'run.cpu_bound must be the real function in worker'
+        assert not result['fastapi_loaded'], 'fastapi must not load in worker'
+        assert result['elapsed_ms'] < 500, f"stub import took {result['elapsed_ms']:.1f} ms"
+''')
+
+
+def test_worker_gets_stubs(tmp_path):
+    script = tmp_path / 'worker_app.py'
+    script.write_text(WORKER_CODE)
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True, timeout=60, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+# The goal function (#5684): when an official example spawns a worker, re-importing the example module must NOT
+# pull in the web framework. 'progress' defines its UI inside @ui.page; 'menu_and_tabs' defines it at module level
+# with `with ui.x():` blocks — between them they cover both idiomatic shapes, each ending in a bare ui.run().
+@pytest.mark.parametrize('example', ['progress', 'menu_and_tabs'])
+def test_official_example_worker_reimport_is_framework_free(example, tmp_path):
+    example_main = EXAMPLES / example / 'main.py'
+    assert example_main.is_file(), f'missing example: {example_main}'
+    driver = tmp_path / 'driver.py'
+    driver.write_text(dedent(f'''\
+        import os, sys, runpy, multiprocessing as mp
+        os.environ['NICEGUI_WORKER_STUBS'] = '1'
+
+        def worker(q):
+            try:
+                runpy.run_path({str(example_main)!r}, run_name='__mp_main__')  # what mp.spawn does to the user's main
+            except SystemExit:
+                pass
+            q.put({{'fastapi': 'fastapi' in sys.modules,
+                    'ui_is_stub': type(sys.modules.get('nicegui.ui')).__name__ == 'WhateverModule'}})
+
+        if __name__ == '__main__':
+            ctx = mp.get_context('spawn')
+            q = ctx.Queue()
+            p = ctx.Process(target=worker, args=(q,))
+            p.start(); print(q.get(timeout=60)); p.join()
+    '''))
+    result = subprocess.run([sys.executable, str(driver)], capture_output=True, text=True, timeout=90, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+    out = eval(result.stdout.strip().splitlines()[-1])  # pylint: disable=eval-used
+    assert out['ui_is_stub'], f'{example}: ui must be stubbed in the worker'
+    assert not out['fastapi'], f'{example}: re-importing the example in a worker must not import fastapi'
+
+
+def test_fresh_main_process_never_stubbed():
+    code = dedent('''\
+        import os, sys
+        os.environ['NICEGUI_WORKER_STUBS'] = '1'  # even with the marker present...
+        import nicegui                              # ...a fresh MainProcess must get the real package
+        from nicegui import ui
+        assert type(sys.modules['nicegui.ui']).__name__ != 'WhateverModule'
+        assert ui.label.__name__ == 'Label'
+    ''')
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_marker_not_set_means_real_import_in_child(tmp_path):
+    script = tmp_path / 'no_marker_app.py'
+    script.write_text(dedent('''\
+        import multiprocessing as mp
+        import os
+        import sys
+        os.environ.pop('NICEGUI_WORKER_STUBS', None)  # the surrounding pytest process may have it set
+
+        def child(queue):
+            import nicegui
+            queue.put(type(sys.modules.get('nicegui.ui', None)).__name__ if 'nicegui.ui' in sys.modules else 'unloaded')
+
+        if __name__ == '__main__':
+            ctx = mp.get_context('spawn')
+            q = ctx.Queue()
+            p = ctx.Process(target=child, args=(q,))
+            p.start()
+            assert q.get(timeout=30) != 'WhateverModule'
+            p.join()
+    '''))
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True, timeout=60, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
*🧱 Brick PR (拋磚引玉, [chengyu-throw-brick-attract-jade](https://github.com/evnchn/chengyu-skill-catalog)) — rough-on-purpose first pass on the evnchn fork for review/selection; NOT aimed at upstream as-is. Drafted overnight by Claude Code under Evan's standing instructions; all numbers reproduced locally; adversarially code-reviewed (subagent) and minimized against a concrete goal function.*

Closes the worker side of #5684. Two commits, one PR — the split is logical, not separately shippable (commit 2 depends on commit 1).

## The goal function

Two official examples define the target, covering both idiomatic shapes (each ends in a bare `ui.run()`):
- **`examples/progress/main.py`** — UI inside `@ui.page`, uses `run.cpu_bound` + `Manager()`
- **`examples/menu_and_tabs/main.py`** — UI at module level with `with ui.x():` blocks

**Goal:** when these spawn a worker subprocess, re-importing the example module must not import FastAPI/socketio, and must be near-instant. Encoded as a parametrized regression test (`tests/test_worker_stubs.py::test_official_example_worker_reimport_is_framework_free`).

## Why #5303 (merged) wasn't enough

`nicegui/__init__.py` was still fully eager, so `from nicegui import ui` re-paid FastAPI + socketio/engineio/aiohttp/redis + `App()` on every subprocess spawn. Falko, post-#5303: *"the situation hasn't improved fundamentally."*

## Commit 1 — lazy package import (the enabler)

PEP 562 `__getattr__` + `_LAZY_IMPORTS` in `nicegui/__init__.py` (mirrors `ui.py`); `core.py` drops its module-level `socketio` import (→ `TYPE_CHECKING`) and materializes `core.app`/`core.sio` on first access; `NiceGUIJSONResponse` moves to `json/response.py` so `nicegui.json` stops importing FastAPI. A `_PackageModule` class gives `app`/`context` data-descriptor properties — required because the import machinery binds the `nicegui.app`/`nicegui.context` submodules as package attributes, which would otherwise shadow the instances (found via a real `test_storage.py` failure; mock-patch round-trip preserved per code review).

`import nicegui`: **223ms → 3.6ms.**

**Honest caveat (Evan caught this):** commit 1 *alone does not speed up real apps' workers.* The idiom ends in `ui.run()`, which touches `core.app` (ui_run.py:162) before the worker early-return — re-materializing FastAPI. Measured worker re-import of `progress` under commit 1 only: **495ms, FastAPI loaded.** Commit 1's standalone value is the bare-`import` win (CLI/scripts) and being the enabler below.

## Commit 2 — worker stub modules (the actual fix)

Resurrects Falko's #4471 PoC. A marker `NICEGUI_WORKER_STUBS` (set by `ui.run()`) + `_worker_stubs.install()` pre-fills `sys.modules` with no-op `Whatever` stubs for every top-level module except `{run, core, helpers, native, json, logging, optional_features, version}`. Module-level `ui.label(...)`, `with ui.row():`, `@ui.page`, `ui.run()` all become no-ops in workers.

#4471's three wounds, healed:
1. **reload mode** — marker popped before `ChangeReload` spawns the (real) server child, re-set in the child's own `ui.run()` early-return so *its* workers inherit it; native webview child spawned before the marker (it needs real `core.app.native.*`); not set at all under pytest (avoids test-order coupling).
2. **Ctrl-C** & 3. **pytest teardown** — `run`/`core`/`helpers` stay *real* (cheap after commit 1), so `core.app.is_stopping` and `helpers.is_pytest()` work untouched, instead of being commented out as in the PoC.

Stubs activate only when the marker is present **and** the process isn't `MainProcess`, so a `subprocess.Popen`-launched independent app is never silently stubbed.

## Results (M4 Air, py3.12.11, idle)

| | main | this PR (worker) |
|---|---|---|
| worker re-import `examples/progress` | 495ms, FastAPI ❌ | **14ms, FastAPI-free ✅** |
| worker re-import `examples/menu_and_tabs` | 328ms, FastAPI ❌ | **1.7ms ✅** |
| bare `import nicegui` | 223ms | **3.6ms** |
| first 10× `run.cpu_bound` (steady 1.01s) | 1.50s | **1.09s** |

For comparison the loky proposal (#5574) measured first-call 1.07–1.11s but adds two dependencies + a `register_pickle_by_value` wart; this needs **zero new deps** and makes main guards unnecessary for UI code.

## Minimization

`Whatever` carries only the dunders the goal exercises — `__getattr__`, `__call__`, `__enter__/__exit__` (menu_and_tabs `with`-blocks), `__mro_entries__` (`class X(ui.element)`), `__getitem__` (native `Handler[X]`, verified), `__init__`. Dropped the speculative `__add__`/`__setitem__`/`__iter__`/`__bool__` after confirming all three examples + native pass without them.

## Verification

- Full suite: **940 passed, 2 xfailed**; 8 `test_dark_mode` failures are pre-existing and reproduce identically on untouched main (host macOS dark mode; `dark=None` follows OS).
- pre-commit / mypy (243 files) / pylint **10.00** clean.
- E2E: reload (server real, workers stubbed, hot-reload respawn, clean SIGINT), native window, fresh-MainProcess immunity — all verified.
- Adversarial subagent review; all Critical/Important findings fixed (stub-mode `core.app` falsy fallthrough, mock-patch deleter crash, vacuous test assertion).

## Known rough edges (deliberately left)

1. Workers that *read* values from stubbed modules get `Whatever` (falsy, empty-iter) — documented in `_worker_stubs.py`; inherent to stubs.
2. `import nicegui.elements.button` (submodule-path) fails in stub mode; `from nicegui import ui` works.
3. No `NICEGUI_EAGER_IMPORT` escape hatch yet (lazy_loader ships one; cheap to add — the #1 lazy-import footgun per PEP 690's rejection record is deferred-exception relocation).
4. REPL untested (SciPy's PackageLoader died there — SPEC-1). Windows/Linux-fork matrix untested (fork inherits real modules → no benefit, no cost).

## Choice points for Evan

- [ ] Marker name `NICEGUI_WORKER_STUBS`?
- [ ] Ship `NICEGUI_EAGER_IMPORT` escape hatch here or follow-up?
- [ ] Squash to one commit, or keep the two-commit enabler/stubs split?
- [ ] Worth also moving `ui.run()`'s worker early-return above the `core.app` touch (line 162)? Gives the `@ui.page` idiom a partial win even *without* stubs — but doesn't help module-level-UI examples, so stubs stay the general fix.
