### PR TITLE
[overnight] zauberzeug#5613 rebased over the zauberzeug#5916 lazy-ui rewrite

### DIFF
--- a/nicegui/elements/popup_edit.py
+++ b/nicegui/elements/popup_edit.py
@@ -1,0 +1,48 @@
+from ..elements.mixins.disableable_element import DisableableElement
+from ..events import Handler, UiEventArguments, handle_event
+
+
+class PopupEdit(DisableableElement):
+    def __init__(self, *,
+                 on_show: Handler[UiEventArguments] | None = None,
+                 on_hide: Handler[UiEventArguments] | None = None,) -> None:
+        """Popup Edit
+
+        This element is based on Quasar's `QPopupEdit <https://quasar.dev/vue-components/popup-edit>`_ component.
+        It provides a popup editor that can be used to edit text or other content in a popup dialog.
+
+        NOTE: We only use the popup edit as a container for other elements.
+
+        - The JavaScript value of the popup edit will not be used.
+        - Rather, value handling is done by the child elements using `NiceGUI's data binding <https://nicegui.io/documentation/section_binding_properties>`_.
+
+        :param on_show: callback to execute when the popup editor is shown
+        :param on_hide: callback to execute when the popup editor is hidden
+        """
+        super().__init__(tag='q-popup-edit')
+        if on_show:
+            self.on_show(on_show)
+        if on_hide:
+            self.on_hide(on_hide)
+
+    def show(self) -> None:
+        """Open the popup editor."""
+        self.run_method('show')
+
+    def hide(self) -> None:
+        """Close the popup editor."""
+        self.run_method('hide')
+
+    def on_show(self, callback: Handler[UiEventArguments]) -> None:
+        """Register a handler to be called when the popup editor is shown.
+
+        :param handler: callback to execute when the popup editor is shown
+        """
+        self.on('show', lambda: handle_event(callback, UiEventArguments(sender=self, client=self.client)), args=[])
+
+    def on_hide(self, callback: Handler[UiEventArguments]) -> None:
+        """Register a handler to be called when the popup editor is hidden.
+
+        :param handler: callback to execute when the popup editor is hidden
+        """
+        self.on('hide', lambda: handle_event(callback, UiEventArguments(sender=self, client=self.client)), args=[])

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -81,6 +81,7 @@ _LAZY_IMPORTS = {
     'pagination': ('.elements.pagination', 'Pagination'),
     'parallax': ('.elements.parallax', 'Parallax'),
     'plotly': ('.elements.plotly', 'Plotly'),
+    'popup_edit': ('.elements.popup_edit', 'PopupEdit'),
     'circular_progress': ('.elements.progress', 'CircularProgress'),
     'linear_progress': ('.elements.progress', 'LinearProgress'),
     'matplotlib': ('.elements.pyplot', 'Matplotlib'),
@@ -240,6 +241,7 @@ __all__ = [
     'pagination',
     'parallax',
     'plotly',
+    'popup_edit',
     'pyplot',
     'query',
     'radio',
@@ -369,6 +371,7 @@ if TYPE_CHECKING:
     from .elements.pagination import Pagination as pagination
     from .elements.parallax import Parallax as parallax
     from .elements.plotly import Plotly as plotly
+    from .elements.popup_edit import PopupEdit as popup_edit
     from .elements.progress import CircularProgress as circular_progress
     from .elements.progress import LinearProgress as linear_progress
     from .elements.pyplot import Matplotlib as matplotlib

--- a/website/documentation/content/popup_edit_documentation.py
+++ b/website/documentation/content/popup_edit_documentation.py
@@ -1,0 +1,18 @@
+from nicegui import app, ui
+
+from . import doc
+
+
+@doc.demo(ui.popup_edit)
+def main_demo() -> None:
+    # from nicegui import app, ui
+    app.storage.client['name'] = 'NiceGUI User'
+
+    with ui.label().bind_text_from(app.storage.client, 'name'):
+        with ui.popup_edit(on_show=lambda _: ui.notify('Shown!'),
+                           on_hide=lambda _: ui.notify('Hidden!')) as popup:
+            ui.input().bind_value(app.storage.client, 'name')
+    ui.button('Force show popup edit', on_click=popup.show)
+
+
+doc.reference(ui.popup_edit)

--- a/website/documentation/content/section_controls.py
+++ b/website/documentation/content/section_controls.py
@@ -2,6 +2,7 @@ from . import (
     badge_documentation,
     button_documentation,
     button_dropdown_documentation,
+    popup_edit_documentation,
     button_group_documentation,
     checkbox_documentation,
     codemirror_documentation,
@@ -51,6 +52,7 @@ doc.intro(rating_documentation)
 doc.intro(joystick_documentation)
 doc.intro(input_documentation)
 doc.intro(textarea_documentation)
+doc.intro(popup_edit_documentation)
 doc.intro(codemirror_documentation)
 doc.intro(xterm_documentation)
 doc.intro(number_documentation)


### PR DESCRIPTION
> 🧱 Overnight brick (2026-06-13, agent-drafted) — staged for Evan's review; nothing posted upstream. 拋磚引玉.

**TL;DR:** zauberzeug/nicegui#5613 (popup edit) rebased over the zauberzeug/nicegui#5916 lazy-ui rewrite (`_LAZY_IMPORTS` dict + `TYPE_CHECKING` + `__getattr__` in `nicegui/ui.py`).

**Upstream:** zauberzeug/nicegui#5613

**Gates:** pre-commit, mypy, pylint + targeted pytest — green.

**Rough spots:**
- The lazy-ui conflict resolution (3 alphabetical lines + lazy-import test) is the part worth eyeballing; detail in the morning pack.