### PR TITLE
[overnight] zauberzeug#6056 rebase verification (content-identical, re-parented)

### DIFF
--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -1,4 +1,5 @@
 import asyncio
+import enum
 import logging
 import signal
 import traceback
@@ -8,7 +9,7 @@ from concurrent.futures.process import BrokenProcessPool
 from contextlib import suppress
 from functools import partial
 from pickle import PicklingError
-from typing import Any, TypeVar
+from typing import Any, Generic, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -19,6 +20,46 @@ thread_pool = ThreadPoolExecutor()
 
 P = ParamSpec('P')
 R = TypeVar('R')
+
+
+class _Sentinel(enum.Enum):
+    NONE_MARKER = 'none_marker'
+
+
+NONE_MARKER = _Sentinel.NONE_MARKER
+'''Sentinel returned by :class:`wrap_none`-wrapped callbacks when they legitimately return ``None``.
+
+Use ``result is run.NONE_MARKER`` to detect this case. Plain ``result is None`` then means the
+``cpu_bound`` / ``io_bound`` call was cancelled or the app is shutting down.
+'''
+
+
+class wrap_none(Generic[P, R]):  # pylint: disable=invalid-name
+    """Wrap a callable so that a legitimate ``None`` return becomes :data:`NONE_MARKER`.
+
+    Use to distinguish "the callback returned ``None``" from "``cpu_bound`` / ``io_bound`` aborted"
+    when both can occur::
+
+        result = await run.cpu_bound(run.wrap_none(my_func), arg1)
+        if result is None:
+            ...  # run was cancelled / app shutting down
+        elif result is run.NONE_MARKER:
+            ...  # my_func returned None
+        else:
+            ...  # real value
+
+    Implemented as a module-level callable class (not a closure) so the wrapper itself is picklable
+    and survives ``cpu_bound``'s process boundary.
+    """
+
+    def __init__(self, fn: Callable[P, R]) -> None:
+        self.fn = fn
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R | _Sentinel:
+        result = self.fn(*args, **kwargs)
+        if result is None:
+            return NONE_MARKER
+        return result
 
 
 def setup() -> None:
@@ -58,9 +99,9 @@ def safe_callback(callback: Callable, *args, **kwargs) -> Any:
         raise SubprocessException(type(e).__name__, str(e), traceback.format_exc()) from None
 
 
-async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
     if core.app.is_stopping:
-        return  # type: ignore  # the assumption is that the user's code no longer cares about this value
+        return None
     try:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(executor, partial(callback, *args, **kwargs))
@@ -69,16 +110,20 @@ async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs:
             raise
     except asyncio.CancelledError:
         pass
-    return  # type: ignore  # the assumption is that the user's code no longer cares about this value
+    return None
 
 
-async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
     """Run a CPU-bound function in a separate process.
 
     `run.cpu_bound` needs to execute the function in a separate process.
     For this it needs to transfer the whole state of the passed function to the process (which is done with pickle).
     It is encouraged to create static methods (or free functions) which get all the data as simple parameters (eg. no class/ui logic)
     and return the result (instead of writing it in class properties or global variables).
+
+    Returns ``None`` (instead of the callback's result) when the call is cancelled or the app is shutting down.
+    If the callback itself may legitimately return ``None``, wrap it with :class:`wrap_none`
+    to distinguish the two cases.
     """
     global process_pool  # pylint: disable=global-statement # noqa: PLW0603
 
@@ -100,8 +145,13 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
             raise e
 
 
-async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
-    """Run an I/O-bound function in a separate thread."""
+async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
+    """Run an I/O-bound function in a separate thread.
+
+    Returns ``None`` (instead of the callback's result) when the call is cancelled or the app is shutting down.
+    If the callback itself may legitimately return ``None``, wrap it with :class:`wrap_none`
+    to distinguish the two cases.
+    """
     return await _run(thread_pool, callback, *args, **kwargs)
 
 

--- a/nicegui/welcome.py
+++ b/nicegui/welcome.py
@@ -20,7 +20,7 @@ async def collect_urls() -> None:
     protocol = os.environ.get('NICEGUI_PROTOCOL')
     if not host or not port or not protocol:
         return
-    ips = set((await run.io_bound(_get_all_ips)) if host == '0.0.0.0' else [])
+    ips = set((await run.io_bound(_get_all_ips) or []) if host == '0.0.0.0' else [])
     ips.discard('127.0.0.1')
     sorted_ips = ['localhost' if host == '0.0.0.0' else host, *sorted(ips)]
     urls = [format_url(protocol, ip, int(port)) for ip in sorted_ips]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,6 +8,7 @@ from pickle import PicklingError
 import pytest
 
 from nicegui import app, run, ui
+from nicegui.app.app import State
 from nicegui.testing import User
 
 
@@ -93,3 +94,41 @@ async def test_run_cpu_bound_survive_bad_function(user: User):
 
     await user.open('/')
     await user.should_see('excellent')
+
+
+@pytest.mark.parametrize('func', [run.cpu_bound, run.io_bound])
+async def test_returns_none_when_app_is_stopping(user: User, func: Callable):
+    @ui.page('/')
+    async def index():
+        original_state = app._state  # pylint: disable=protected-access
+        app._state = State.STOPPING  # pylint: disable=protected-access
+        try:
+            result = await func(delayed_hello)
+            ui.label(f'result={result}')
+        finally:
+            app._state = original_state  # pylint: disable=protected-access
+
+    await user.open('/')
+    await user.should_see('result=None')
+
+
+def returns_none() -> None:
+    return None
+
+
+def returns_value() -> str:
+    return 'real'
+
+
+@pytest.mark.parametrize('func', [run.cpu_bound, run.io_bound])
+async def test_wrap_none_disambiguates(user: User, func: Callable):
+    @ui.page('/')
+    async def index():
+        none_result = await func(run.wrap_none(returns_none))
+        value_result = await func(run.wrap_none(returns_value))
+        ui.label(f'none={none_result is run.NONE_MARKER}')
+        ui.label(f'value={value_result}')
+
+    await user.open('/')
+    await user.should_see('none=True')
+    await user.should_see('value=real')

--- a/website/documentation/content/section_action_events.py
+++ b/website/documentation/content/section_action_events.py
@@ -103,6 +103,37 @@ def io_bound_demo():
     ui.button('Download', on_click=handle_click)
 
 
+@doc.demo('Distinguishing cancellation from a legitimate `None`', '''
+    Both `run.cpu_bound` and `run.io_bound` return `None` when the call is cancelled
+    or the app is shutting down — regardless of the callback's signature.
+    If your callback may itself legitimately return `None`, you cannot tell the two cases apart from the return value alone.
+
+    Wrap the callback with `run.wrap_none` so a legitimate `None` becomes `run.NONE_MARKER` (a picklable sentinel).
+    Plain `None` then unambiguously means the call was aborted.
+
+    Note: `run.wrap_none` is implemented as a callable class rather than a closure,
+    so the wrapper itself survives pickling across `cpu_bound`'s process boundary.
+    A bare `object()` does not — `pickle` constructs a fresh instance on the parent side,
+    and `result is SENTINEL` then always returns `False`.
+''')
+def sentinel_demo():
+    from nicegui import run
+
+    def lookup(key: str) -> str | None:
+        return None if key == 'missing' else f'value_for_{key}'
+
+    async def handle_click():
+        result = await run.io_bound(run.wrap_none(lookup), 'missing')
+        if result is None:
+            ui.notify('run was cancelled / app shutting down')
+        elif result is run.NONE_MARKER:
+            ui.notify('lookup returned None (genuine)')
+        else:
+            ui.notify(f'lookup returned {result}')
+
+    ui.button('Lookup', on_click=handle_click)
+
+
 doc.intro(run_javascript_documentation)
 doc.intro(clipboard_documentation)
 doc.intro(event_documentation)


### PR DESCRIPTION
> 🧱 Overnight brick (2026-06-13, agent-drafted) — staged for Evan's review; nothing posted upstream. 拋磚引玉.

**TL;DR:** Rebase verification for zauberzeug/nicegui#6056: content-identical to the upstream PR, just re-parented onto current main. Purpose is a clean diff + fresh CI signal, not new work.

**Upstream:** zauberzeug/nicegui#6056

**Gates:** pre-commit, mypy, pylint + targeted pytest — green.

**Rough spots:**
- None expected (verification-only); if CI diverges from upstream's, that itself is the finding.