### PR TITLE
[overnight] #6055 echo-skip rebased onto main (post-#6104 merge)

### DIFF
--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -17,7 +17,7 @@ class ValueElement(Element, Generic[ValueT]):
     LOOPBACK: bool | None = True
     '''Whether to set the new value directly on the client or after getting an update from the server.
 
-    - ``True``: The value is updated by sending a change event to the server which responds with an update.
+    - ``True``: The value is updated by sending a change event to the server; the server echoes back unless the value matches what the client just sent.
     - ``False``: The value is updated by setting the VALUE_PROP directly on the client.
     - ``None``: The value is updated automatically by the Vue element.
     '''
@@ -46,10 +46,15 @@ class ValueElement(Element, Generic[ValueT]):
             self.on_value_change(on_value_change)
 
         def handle_change(e: GenericEventArguments) -> None:
-            self._send_update_on_value_change = self.LOOPBACK is True
-            self.set_value(self._event_args_to_value(e))
-            self._send_update_on_value_change = True
+            self._send_update_on_value_change = False
+            try:
+                self.set_value(self._event_args_to_value(e))
+            finally:
+                self._send_update_on_value_change = True
             self._client_value = e.args if self.LOOPBACK is False else _NO_CLIENT_VALUE
+            # skip the echo when the server's value matches what the client locally rendered (see #5933)
+            if self.LOOPBACK is True and self._props[self.VALUE_PROP] != e.args:
+                self.update()
         self.on(f'update:{self.VALUE_PROP}', handle_change, [None], throttle=throttle)
 
     def on_value_change(self, callback: Handler[ValueChangeEventArguments[ValueT]]) -> Self:

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -272,8 +272,10 @@ function renderRecursively(elements, id, propsContext) {
         else setTimeout(delayed_emitter, 10);
       };
       throttle(delayed_emitter, event.throttle, event.leading_events, event.trailing_events, event.listener_id);
-      if (element.props["loopback"] === False && event.type == "update:modelValue") {
-        element.props["model-value"] = args;
+      // mirror locally so the client-rendered value survives re-render when the server elides the echo (see #5933)
+      if ((element.props["loopback"] === true || element.props["loopback"] === false)
+          && event.type == "update:modelValue") {
+        element.props["model-value"] = args[0];
       }
     };
 

--- a/tests/test_value_echo_skip.py
+++ b/tests/test_value_echo_skip.py
@@ -1,0 +1,175 @@
+"""Tests for the client-value echo skip optimization in ValueElement (see #5933)."""
+
+from collections.abc import Callable
+
+import pytest
+
+from nicegui import ui
+from nicegui.elements.mixins.value_element import ValueElement
+from nicegui.helpers import event_type_to_camel_case
+from nicegui.testing import User
+
+
+class PlainValue(ValueElement[str]):
+
+    def __init__(self, *, value: str = '', on_change: Callable | None = None) -> None:
+        super().__init__(tag='div', value=value, on_value_change=on_change)
+
+
+class TruncatingValue(ValueElement[str]):
+
+    def __init__(self, *, value: str = '') -> None:
+        super().__init__(tag='div', value=value)
+
+    def _value_to_model_value(self, value):  # type: ignore[override]
+        return (value or '')[:3]
+
+
+def _outbox_has_update_for(element) -> bool:
+    return element.id in element.client.outbox.updates
+
+
+def _simulate_client_change(element, value) -> None:
+    event_name = event_type_to_camel_case(f'update:{element.VALUE_PROP}')
+    listeners = element._event_listeners  # pylint: disable=protected-access
+    try:
+        listener_id = next(lid for lid, listener in listeners.items() if listener.type == event_name)
+    except StopIteration:
+        types = sorted({listener.type for listener in listeners.values()})
+        raise AssertionError(f'no {event_name!r} listener on {element!r}; have: {types}') from None
+    element._handle_event({'listener_id': listener_id, 'args': value})  # pylint: disable=protected-access
+
+
+def _single(user: User, kind):
+    return next(iter(user.find(kind=kind).elements))
+
+
+async def test_pure_echo_is_skipped(user: User):
+    @ui.page('/')
+    def page():
+        PlainValue(value='')
+
+    await user.open('/')
+    elem = _single(user, PlainValue)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, 'hello')
+    assert elem.value == 'hello'
+    assert not _outbox_has_update_for(elem)
+
+
+async def test_server_transform_is_echoed(user: User):
+    @ui.page('/')
+    def page():
+        TruncatingValue(value='')
+
+    await user.open('/')
+    elem = _single(user, TruncatingValue)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, 'abcdef')
+    assert elem._props[elem.VALUE_PROP] == 'abc'  # pylint: disable=protected-access
+    assert _outbox_has_update_for(elem)
+
+
+async def test_on_change_correction_is_echoed(user: User):
+    @ui.page('/')
+    def page():
+        PlainValue(value='', on_change=lambda e: setattr(e.sender, 'value', str(e.value).upper()))
+
+    await user.open('/')
+    elem = _single(user, PlainValue)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, 'hello')
+    assert elem.value == 'HELLO'
+    assert _outbox_has_update_for(elem)
+
+
+async def test_side_effect_update_in_handler_flows_through(user: User):
+    @ui.page('/')
+    def page():
+        PlainValue(value='', on_change=lambda e: e.sender.classes('error'))
+
+    await user.open('/')
+    elem = _single(user, PlainValue)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, 'x')
+    assert _outbox_has_update_for(elem)
+
+
+async def test_loopback_false_still_skips(user: User):
+    @ui.page('/')
+    def page():
+        ui.input(value='')
+
+    await user.open('/')
+    inp = _single(user, ui.input)
+    inp.client.outbox.updates.clear()
+    _simulate_client_change(inp, 'hello')
+    assert inp.value == 'hello'
+    assert not _outbox_has_update_for(inp)
+
+
+async def test_to_dict_still_carries_value(user: User):
+    @ui.page('/')
+    def page():
+        PlainValue(value='initial')
+
+    await user.open('/')
+    elem = _single(user, PlainValue)
+    _simulate_client_change(elem, 'client_typed')
+    assert elem._to_dict()['props'][elem.VALUE_PROP] == 'client_typed'  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize('factory, kind, emit', [
+    (lambda: ui.checkbox('cb'), ui.checkbox, True),
+    (lambda: ui.switch('sw'), ui.switch, True),
+    (lambda: ui.dialog(), ui.dialog, True),
+    (lambda: ui.menu(), ui.menu, True),
+    (lambda: ui.expansion('exp'), ui.expansion, True),
+    (lambda: ui.select(options=['a', 'b'], value='a'), ui.select, {'value': 1, 'label': 'b'}),
+])
+async def test_real_loopback_true_elements_skip_echo(user: User, factory, kind, emit):
+    @ui.page('/')
+    def page():
+        factory()
+
+    await user.open('/')
+    elem = _single(user, kind)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, emit)
+    assert not _outbox_has_update_for(elem)
+
+
+async def test_rapid_toggles_do_not_enqueue_outbox_update(user: User):
+    @ui.page('/')
+    def page():
+        ui.checkbox('cb')
+
+    await user.open('/')
+    cb = _single(user, ui.checkbox)
+    cb.client.outbox.updates.clear()
+    for i in range(50):
+        _simulate_client_change(cb, bool(i % 2))
+    assert cb.id not in cb.client.outbox.updates
+
+
+async def test_set_value_exception_does_not_leak_suppression(user: User, caplog: pytest.LogCaptureFixture):
+    class Raising(ValueElement[str]):
+        def __init__(self) -> None:
+            super().__init__(tag='div', value='')
+
+        def _value_to_model_value(self, value):  # type: ignore[override]
+            if value == 'BOOM':
+                raise ValueError('nope')
+            return value
+
+    @ui.page('/')
+    def page():
+        Raising()
+
+    await user.open('/')
+    elem = _single(user, Raising)
+    _simulate_client_change(elem, 'BOOM')  # handle_event swallows + logs the ValueError
+    caplog.clear()
+    elem.client.outbox.updates.clear()
+    elem.value = 'legit'  # server-driven change must still flow
+    assert _outbox_has_update_for(elem)


### PR DESCRIPTION
> 🧱 Overnight brick (2026-06-13, agent-drafted) — staged for Evan's review; nothing posted upstream. 拋磚引玉.

**TL;DR:** Upstream squash-merged zauberzeug#6104 into `main` tonight (`458d65cb`), which made the previous staging branch (`overnight/6055-post-6104`, fork PR #170) conflict — it carried its own copies of the pre-squash #6104 commits. This branch is the same echo-skip change cherry-picked cleanly onto post-merge `main`: **one commit (`597bcc20`) on top of `458d65cb`**, now a plain candidate update for upstream zauberzeug#6055.

### What's in it

- `nicegui/elements/mixins/value_element.py` — `handle_change` with try/finally suppression + trailing `LOOPBACK is True and _props[VALUE_PROP] != e.args` echo-skip, coexisting with #6104's `_client_value` preservation (ordering rationale in the commit message).
- `nicegui/static/nicegui.js` — emitter-mirror extended to `loopback === true || === false`, stores `args[0]` (scalar) instead of `args` (array).
- `tests/test_value_echo_skip.py` — 14 tests.

The cherry-pick of `f5fb10f3` applied **without conflicts**; the final `value_element.py` and `test_value_echo_skip.py` are byte-identical to the reviewed `f5fb10f3` tree, and the `nicegui.js` hunk is identical (remaining tree drift vs `f5fb10f3` is unrelated `main` advancement, e.g. #6103 transports).

### Gates (all on this branch)

| Gate | Result |
|---|---|
| `pytest tests/test_value_echo_skip.py` | 14 passed |
| `pytest tests/test_input.py -k "lagging or props_overrides"` (#6104's tests) | 2 passed |
| `pytest tests/test_select.py tests/test_toggle.py` (smoke) | 38 passed |
| `pre-commit run --files <touched>` | all passed |
| `mypy ./nicegui` | no issues (241 files) |
| `pylint ./nicegui` | 10.00/10 |

### Note for review

Upstream `main` line 2 of `nicegui.js` has `const False = false;` (introduced by the #6104 squash); this branch removes the only usage (`=== False`), leaving that const dead. Kept untouched to stay byte-identical to the reviewed resolution — could be dropped as a one-line cleanup when sending upstream.

Replaces fork PR #170.
