### PR TITLE
[overnight] Re-arm #6105 drain bound for reload=False native apps

### DIFF
--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -182,6 +182,10 @@ def activate(protocol: str, host: str, port: int, title: str, width: int, height
             time.sleep(0.1)
         if shutdown_event is not None:
             shutdown_event.set()
+        # The window is closed, so bound the connection drain, which can hang forever on Windows (#5443).
+        # Without auto-reloading the server runs in this very process and never sees a shutdown event,
+        # so the timeout must be set here as well. Lifespan shutdown (with app.on_shutdown callbacks) is unaffected.
+        Server.instance.config.timeout_graceful_shutdown = 1
         Server.instance.should_exit = True
         while not core.app.is_stopped:
             time.sleep(0.1)


### PR DESCRIPTION
> 🧱 Overnight brick (2026-06-13, agent-drafted) — staged for Evan's review; nothing posted upstream. 拋磚引玉.

**TL;DR:** zauberzeug/nicegui#6105 as written only bounds the connection drain when `reload=True` — `ui_run.py` creates `config.shutdown_event` only in reload mode, so for `reload=False` (the #4970 repro and every packaged native app) the patched `monitor_shutdown_event` thread never starts and the PR is a no-op in the exact mode that hangs. This branch re-arms the same mechanism in the non-reload path: `native_mode.activate()` sets `Server.instance.config.timeout_graceful_shutdown = 1` right before `should_exit = True` (`nicegui/native/native_mode.py`, +4 lines, comment included).

### Why the bound works (live-hang autopsy, zauberzeug/nicegui#5443)

In every hang, a `ConnectionResetError: [WinError 10054]` inside proactor `_call_connection_lost` aborts transport cleanup before it detaches from the asyncio `Server`, so uvicorn's `shutdown()` → `_wait_tasks_to_complete()` → `await server.wait_closed()` never resolves. That await sits **inside** `wait_for(..., timeout=timeout_graceful_shutdown)` — bounding the drain releases it ~1 s later, and lifespan shutdown (`app.on_shutdown`) still runs to completion.

### Windows trial results (DeskPC, Win 11 IoT LTSC, Python 3.12.10, pywebview 6.2.1, WebView2 149, uvicorn 0.49.0 — #4970 repro: 2× `ui.video`, window destroyed at t+8 s, 20× per arm)

| arm | config | code | trials | hangs | on_shutdown ran | destroy→exit |
|---|---|---|---|---|---|---|
| A | `reload=False` | baseline `240db43` | 20 | **8 (40%)** | 12/20 (never in hangs) | 3.2–3.5 s |
| B | `reload=False` | PR #6105 head `738189e` | 20 | **10 (50%)** | 10/20 | 3.3–3.5 s |
| C | `reload=False` + explicit `timeout_graceful_shutdown=1` kwarg | PR head | 20 | 0 | 20/20 | 3.3–3.5 s (12×) / 4.3–4.5 s (8×) |
| D | `reload=True` | baseline + PR head | 15+15 | 0 | 30/30 | 3.4–3.7 s |
| **E** | **`reload=False`** | **this branch `e39697a`** | **20** | **0** | **20/20** | **3.3–3.5 s (12×) / 4.3–4.5 s (8×)** |
| E' | `reload=True` regression | this branch | 5 | 0 | 5/5 | 3.4–3.6 s |

Arm E's bimodal timing matches arm C exactly: the ~4.3–4.5 s cluster (8/20 ≈ the 40% baseline hang rate) is the would-be hangs being released by the 1 s drain bound. Net effect: a 40–50% permanent hang becomes a worst-case ~1 s delayed exit.

Refs: zauberzeug/nicegui#6105, zauberzeug/nicegui#5443, zauberzeug/nicegui#4970. Raw CSVs + repro kit archived on the test box and in `~/nicegui-6105-verify-staging/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
