### PR TITLE
[overnight] Fix native window close hanging on Windows via os._exit (#5443) — V2 verified

### DIFF
--- a/PR-BODY.md
+++ b/PR-BODY.md
@@ -1,0 +1,95 @@
+### Motivation
+
+Fixes #5443 (native window close hangs the process on Windows). When a native-mode
+app is closed, uvicorn's graceful shutdown enters a connection-drain loop that can hang
+**forever** on a ghost Windows connection: a `ConnectionResetError: [WinError 10054]`
+raised inside the proactor's `_call_connection_lost` aborts the transport's cleanup
+before it detaches from the asyncio `Server`, so `server.wait_closed()` never resolves.
+The user closed the window and the process never exits.
+
+This implements the direction @falkoschindler proposed in #5443: in native mode, after
+the window is closed, run the user's `app.on_shutdown` callbacks to completion and then
+`os._exit(0)` — there is no live browser left to gracefully drain, so a hard exit is the
+right call. Supersedes the `timeout_graceful_shutdown=10` default proposed in #5706 /
+#6105 (which truncates legitimately-slow shutdown work and affects non-native users).
+
+### Implementation
+
+**Empirical finding that shapes the design (uvicorn 0.40.0 and 0.49.0, verified from
+source on the test machine):** `Server.shutdown()` runs the connection drain
+*before* lifespan shutdown:
+
+```
+shutdown():
+  close servers / sockets
+  request connection shutdown; sleep(0.1)
+  await wait_for(_wait_tasks_to_complete(), timeout=timeout_graceful_shutdown)   # <-- DRAIN (the hang)
+      └─ ... ; for server: await server.wait_closed()                            # <-- never resolves on the ghost
+  await self.lifespan.shutdown()                                                 # <-- on_shutdown callbacks (AFTER the drain)
+```
+
+So @falkoschindler's *literal* sketch — "wait for lifespan shutdown to complete, then
+`os._exit(0)`" — cannot work: lifespan shutdown is gated behind the very drain that
+hangs. (Verified on real Windows hardware — see candidate V1 below: on a hung trial the
+`on_shutdown` callbacks never run, so the "wait for lifespan" loop spins forever.)
+
+This PR therefore implements the *intent* in a drain-independent way: instead of waiting
+for uvicorn's lifespan shutdown, we drive NiceGUI's own shutdown directly. On native
+window close we schedule `app.stop()` (which runs every `app.on_shutdown` callback) on
+the running event loop via `asyncio.run_coroutine_threadsafe`, wait for it to complete,
+flush stdout/stderr, then `os._exit(0)`. Because the process exits there, uvicorn never
+reaches its own lifespan shutdown, so the handlers run exactly once.
+
+Two call sites cover both modes:
+
+- `nicegui/native/native_mode.py` — `_hard_exit_after_shutdown`, called from the
+  window-close watcher `check_shutdown` (the `reload=False` path used by the #4970 repro
+  and every packaged native app).
+- `nicegui/server.py` — `monitor_shutdown_event` (the `reload=True` path).
+
+Scoped to native mode only; non-native shutdown is untouched. For non-native scenarios
+that want a bounded drain, `timeout_graceful_shutdown` remains available as a uvicorn
+kwarg through `**kwargs`.
+
+### Progress
+
+- [x] The PR title is a short phrase starting with a verb.
+- [x] The implementation is complete.
+- [x] This PR does not address a security issue.
+- [ ] Pytests have been added/updated or are not necessary. <!-- native-mode window-close hard-exit is verified by a Windows hardware fleet test (see below); not unit-testable in CI -->
+- [ ] Documentation has been added/updated or is not necessary.
+- [x] No breaking changes to the public API.
+
+---
+
+### Windows verification (real hardware)
+
+DeskPC: Windows 11 IoT Enterprise LTSC 10.0.26100, Python 3.12.10, pywebview 6.2.1,
+WebView2 149.0.4022.62, uvicorn 0.49.0. Repro per #4970: 2 × `ui.video`,
+`ui.run(native=True, reload=False)`, a `ui.timer` destroys the native window after 8 s,
+an `app.on_shutdown` writes+flushes a marker; the runner measures destroy→process-exit
+and kills any tree still alive at +30 s. 20 trials `reload=False` + 5 trials `reload=True`
+per candidate, run in the interactive session via scheduled task (WebView2 won't start
+over SSH). Both candidates installed into fresh venvs from their own branch.
+
+| candidate                                                    | mode           | trials | hangs        | clean exits | on_shutdown ran                     | destroy→exit  |
+| ------------------------------------------------------------ | -------------- | ------ | ------------ | ----------- | ----------------------------------- | ------------- |
+| **V1** (Falko literal: wait for lifespan, then `os._exit`)   | `reload=False` | 20     | **11 (55%)** | 9           | **9/20** (only the non-hung trials) | 3.3–3.6 s     |
+| V1                                                           | `reload=True`  | 5      | 0            | 5           | 5/5                                 | 3.0–3.4 s     |
+| **V2** (this PR: run `app.stop()` directly, then `os._exit`) | `reload=False` | 20     | **0**        | **20**      | **20/20**                           | **3.0–3.3 s** |
+| V2                                                           | `reload=True`  | 5      | 0            | 5           | 5/5                                 | 3.0–3.2 s     |
+
+**V1 deadlocks ~55% of the time, exactly as the uvicorn-ordering analysis predicts.** On
+a hung trial the `on_shutdown` callbacks never ran (`on_shutdown 9/20`, all 9 on the
+non-hung trials) — because waiting on lifespan-shutdown-completion can never succeed when
+lifespan shutdown is gated behind the drain that is itself stuck. So Falko's literal
+sketch is not viable; it reproduces the very hang it set out to fix.
+
+**V2 (this PR) is 0 hangs in 20 `reload=False` trials, with `on_shutdown` running every
+single time, and a clean 5/5 `reload=True` regression pass.** Driving `app.stop()` ourselves
+makes the exit even snappier than the timeout-bounded alternative (a flat 3.0–3.3 s, with
+none of the ~4.5 s "released after the 1 s drain timeout" cluster) because there is no
+timer to wait out — the handlers run and the process exits immediately.
+
+Raw CSVs and the rerunnable kit are archived on the test machine and mirrored to
+`~/nicegui-6105-verify-staging/results/` (`results-v1*.csv`, `results-v2*.csv`).

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import _thread
+import asyncio
 import multiprocessing as mp
+import os
 import pickle
 import queue
 import socket
@@ -18,7 +19,6 @@ from typing import Any
 
 from .. import core, helpers, optional_features
 from ..logging import log
-from ..server import Server
 from . import native, window_icon
 from .event_manager import event_manager
 
@@ -173,6 +173,26 @@ def _warn_if_esm_unsupported(window: webview.Window) -> None:
     window.events.loaded += check
 
 
+def _hard_exit_after_shutdown() -> None:
+    """Run NiceGUI's own shutdown (app.on_shutdown callbacks), then hard-exit the process.
+
+    The native window is closed, so there is no live browser left to gracefully say goodbye to.
+    We drive `app.stop()` directly on the running event loop instead of relying on uvicorn's
+    own lifespan shutdown: uvicorn runs its connection drain *before* lifespan shutdown, and that
+    drain can hang forever on a ghost Windows connection (#5443). Running `app.stop()` ourselves
+    lets the user's `on_shutdown` work complete first, then `os._exit(0)` bypasses the stuck drain.
+    Because the process exits here, uvicorn never reaches its own lifespan shutdown, so the
+    handlers run exactly once.
+    """
+    if core.loop is not None and core.loop.is_running() and not core.app.is_stopped:
+        future = asyncio.run_coroutine_threadsafe(core.app.stop(), core.loop)
+        with suppress(Exception):
+            future.result(timeout=30)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
+
+
 def activate(protocol: str, host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool,
              shutdown_event: MultiprocessingEvent | None = None,
              favicon: str | Path | None = None) -> None:
@@ -182,12 +202,7 @@ def activate(protocol: str, host: str, port: int, title: str, width: int, height
             time.sleep(0.1)
         if shutdown_event is not None:
             shutdown_event.set()
-        Server.instance.should_exit = True
-        while not core.app.is_stopped:
-            time.sleep(0.1)
-        _thread.interrupt_main()
-        event_manager.stop()
-        native.remove_queues()
+        _hard_exit_after_shutdown()
 
     if not optional_features.has('webview'):
         log.error('Native mode is not supported in this configuration.\n'

--- a/nicegui/server.py
+++ b/nicegui/server.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import multiprocessing
 import multiprocessing.synchronize
+import os
 import socket
+import sys
 import threading
+from contextlib import suppress
 from typing import Any
 
 import uvicorn
@@ -38,7 +42,18 @@ class Server(uvicorn.Server):
             if (event := self.config.shutdown_event) is not None:
                 def monitor_shutdown_event() -> None:
                     event.wait()
-                    self.should_exit = True
+                    # The native window is closed, so there is no live browser left to gracefully say goodbye to.
+                    # Drive NiceGUI's own shutdown (app.on_shutdown callbacks) directly on the event loop, then
+                    # hard-exit (#5443): this bypasses uvicorn's connection drain, which runs *before* lifespan
+                    # shutdown and can hang forever on a ghost Windows connection. Because the process exits here,
+                    # uvicorn never reaches its own lifespan shutdown, so the handlers run exactly once.
+                    if core.loop is not None and core.loop.is_running() and not core.app.is_stopped:
+                        future = asyncio.run_coroutine_threadsafe(core.app.stop(), core.loop)
+                        with suppress(Exception):
+                            future.result(timeout=30)
+                    sys.stdout.flush()
+                    sys.stderr.flush()
+                    os._exit(0)
                 threading.Thread(target=monitor_shutdown_event, daemon=True).start()
 
         storage.set_storage_secret(self.config.storage_secret, self.config.session_middleware_kwargs)


### PR DESCRIPTION
> 🧱 Overnight brick (2026-06-13, agent-drafted) — staged for Evan's review on the fork; **nothing posted upstream**. 拋磚引玉.

**Replaces the retired `timeout_graceful_shutdown` re-arm (fork #178) with @falkoschindler's `os._exit` direction — empirically settled on real Windows hardware.** Upstream PR #6105 was closed (it deviated + was a no-op for `reload=False`). This is the verified replacement, held for Evan to open upstream against #5443.

---

### Motivation

Fixes #5443 (native window close hangs the process on Windows). When a native-mode app is closed, uvicorn's graceful shutdown enters a connection-drain loop that can hang **forever** on a ghost Windows connection: a `ConnectionResetError: [WinError 10054]` raised inside the proactor's `_call_connection_lost` aborts the transport's cleanup before it detaches from the asyncio `Server`, so `server.wait_closed()` never resolves. The user closed the window and the process never exits.

This implements the direction @falkoschindler proposed in #5443: in native mode, after the window is closed, run the user's `app.on_shutdown` callbacks to completion and then `os._exit(0)` — there is no live browser left to gracefully drain, so a hard exit is the right call.

### Implementation

**Empirical finding that shapes the design (uvicorn 0.40.0 and 0.49.0, verified from source):** `Server.shutdown()` runs the connection drain **before** lifespan shutdown:

```
shutdown():
  await wait_for(_wait_tasks_to_complete(), timeout=timeout_graceful_shutdown)   # DRAIN (the hang) → await server.wait_closed()
  await self.lifespan.shutdown()                                                 # on_shutdown callbacks (AFTER the drain)
```

So Falko's *literal* sketch — "wait for lifespan shutdown to complete, then `os._exit(0)`" — cannot work: lifespan shutdown is gated behind the very drain that hangs (see candidate V1 below — it reproduces the hang ~55% of the time). This PR implements the *intent* drain-independently: on native window close, schedule `app.stop()` (which runs every `app.on_shutdown` callback) on the running loop via `run_coroutine_threadsafe`, wait, flush, then `os._exit(0)`. Two call sites: `native_mode.py` (`reload=False`) and `server.py` (`reload=True`).

### Windows verification (real hardware — DeskPC Win11 LTSC, py3.12.10, pywebview 6.2.1, WebView2 149, uvicorn 0.49.0; #4970 repro, 2×ui.video, destroy-after-8s, on_shutdown marker)

| candidate | mode | trials | hangs | on_shutdown ran | destroy→exit |
|---|---|---|---|---|---|
| **V1** (Falko literal) | `reload=False` | 20 | **11 (55%)** | 9/20 (non-hung only) | 3.3–3.6 s |
| V1 | `reload=True` | 5 | 0 | 5/5 | 3.0–3.4 s |
| **V2 (this PR)** | `reload=False` | 20 | **0** | **20/20** | **3.0–3.3 s** |
| V2 | `reload=True` | 5 | 0 | 5/5 | 3.0–3.2 s |

---

### ⚠️ REVIEW FLAGS (Evan — read before upstreaming)

1. **Conflicts with #6106** — both rewrite `monitor_shutdown_event` in `server.py`. #6106 changes `event.wait()` → poll `is_set()` (its deadlock fix for #5845); V2 keeps `event.wait()` and changes the post-wait action. The correct **combined shape** is: `while not event.is_set(): sleep(0.1)` → `app.stop()` → `os._exit(0)`. Decide whether this PR or #6106 lands first and reconcile; V2's `reload=True` arm only proves *no regression* on this box (it never hangs here), **not** that it fixes #5845's reload deadlock.
2. **Dropped uvicorn/native cleanup** — V2 removes `_thread.interrupt_main()`, `event_manager.stop()`, `native.remove_queues()` because `os._exit` skips everything. Intentional for a terminating process; the OS reclaims the mp queues. Worth your eye that nothing downstream relies on those running.
3. **No CI pytest** — native-window hard-exit isn't unit-testable; verified by the Windows fleet test above. (#6106 by contrast *does* ship a CI-able mechanism test.)
4. **`PR-BODY.md` commit (`fba1909f` is the code; `4d800a31` adds PR-BODY.md)** — drop the PR-BODY.md commit before upstreaming; its content is this description.

Gates: pre-commit + `mypy ./nicegui` (clean) + `pylint ./nicegui` (10.00/10) + `tests/test_lifecycle.py` 6/6. Branches: V1 `overnight/6105-osexit-v1`, V2 `overnight/6105-osexit-v2`, recommended `overnight/6105-osexit-pr`. CSVs: `~/nicegui-6105-verify-staging/results/`.
