### PR TITLE
Use a spawn context for the cpu_bound process pool

### DIFF
--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import inspect
-import multiprocessing
 import warnings
 from collections.abc import Callable
 from multiprocessing import Queue
@@ -12,7 +11,7 @@ from typing import Any
 from .. import run
 from ..logging import log
 
-SPAWN_CONTEXT = multiprocessing.get_context('spawn')  # match uvicorn's ChangeReload worker (#1841)
+SPAWN_CONTEXT = run.SPAWN_CONTEXT  # shared with cpu_bound (#1841)
 
 method_queue: Queue | None = None
 response_queue: Queue | None = None

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import multiprocessing
 import signal
 import traceback
 from collections.abc import Callable
@@ -17,6 +18,9 @@ from . import core, helpers
 process_pool: ProcessPoolExecutor | None = None
 thread_pool = ThreadPoolExecutor()
 
+# cpu_bound must use spawn, not fork, regardless of the global start method (#3644)
+SPAWN_CONTEXT = multiprocessing.get_context('spawn')
+
 P = ParamSpec('P')
 R = TypeVar('R')
 
@@ -25,7 +29,7 @@ def setup() -> None:
     """Setup the process pool. (For internal use only.)"""
     global process_pool  # pylint: disable=global-statement # noqa: PLW0603
     try:
-        process_pool = ProcessPoolExecutor(initializer=_ignore_sigint)
+        process_pool = ProcessPoolExecutor(mp_context=SPAWN_CONTEXT, initializer=_ignore_sigint)
     except NotImplementedError:
         logging.warning('Failed to initialize ProcessPoolExecutor')
 
@@ -95,7 +99,7 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
         try:
             await _run(process_pool, safe_callback, lambda: None)
         except BrokenProcessPool:
-            process_pool = ProcessPoolExecutor(initializer=_ignore_sigint)
+            process_pool = ProcessPoolExecutor(mp_context=SPAWN_CONTEXT, initializer=_ignore_sigint)
         finally:
             raise e
 


### PR DESCRIPTION
### Motivation

`nicegui.run`'s process pool is a bare `ProcessPoolExecutor`, so it inherits the **global** multiprocessing start method — `fork` on Linux/Docker, which is [unsafe for Python](https://pythonspeed.com/articles/python-multiprocessing/) (a multi-threaded parent forking can deadlock the child). So `run.cpu_bound` runs under `fork` whenever the global default isn't `spawn`: with `ui.run(reload=False)` on Linux today, and on Python 3.14 once `forkserver` becomes the default. Surfaced by zauberzeug/rosys#19.

This can't be fixed by setting the global start method on import — that path was removed because it breaks downstream code (#3644). The supported fix is a scoped `mp_context`, which `native.py` already uses for the window subprocess (#1841).

### Implementation

Both pool constructions (`setup()` and the `BrokenProcessPool` restart path) now pass `mp_context=SPAWN_CONTEXT`, a module-level `multiprocessing.get_context('spawn')` in `run.py`; `native.py` reuses it instead of duplicating one. `cpu_bound` is now spawn-based regardless of the global default.

> **Behavior note (Linux):** `spawn` requires `cpu_bound` callables + args to be picklable and the entry script to use `if __name__ == '__main__'`. Already required on macOS/Windows; on Linux, code that leaned on `fork` (closures, unpicklable args) now gets a clear error instead of a silent, deadlock-prone fork.

<details>
<summary><b>Minimal repro — crashes on <code>main</code>, passes here (Linux)</b></summary>

```python
"""Minimal repro for nicegui#182 - run.cpu_bound must use 'spawn', not 'fork'.

Run on Linux (default start method = fork; e.g. inside Docker, or any non-mac box):

    python mre182.py

- On released nicegui 3.13.x (and current main): AssertionError - cpu_bound forked.
- On this PR:                                     prints "OK: cpu_bound ran under spawn".

Why this proves it: a *forked* child inherits the parent's live memory, so it sees the
flag the parent set after import; a *spawned* child re-imports this module fresh, so the
flag is back at its default. (fork is unsafe for Python - it deadlocks with threads/locks;
spawn is the supported start method.)
"""
import asyncio
import multiprocessing

from nicegui import run

inherited_from_parent = False  # a spawned child re-imports and sees this default


def probe(_):
    return inherited_from_parent  # True only if this child inherited parent memory (forked)


async def main():
    global inherited_from_parent
    print(f"global start method: {multiprocessing.get_start_method()!r}")
    inherited_from_parent = True  # set AFTER import; only fork carries it into the child
    run.setup()
    forked = await run.cpu_bound(probe, None)
    assert not forked, 'cpu_bound ran under FORK (broken on Linux) - see nicegui#182'
    print('OK: cpu_bound ran under spawn')
    run.tear_down()


if __name__ == '__main__':
    asyncio.run(main())
```

| nicegui | result |
|---|---|
| released 3.13.x / `main` | `AssertionError: cpu_bound ran under FORK` — exit 1 ❌ |
| this PR | `OK: cpu_bound ran under spawn` — exit 0 ✅ |

macOS/Windows pass both ways (`spawn` is already their default) — the bug is Linux/Docker-only.
</details>

<details>
<summary><b>Verification (Python 3.12.3, Linux, genuine <code>fork</code> default)</b></summary>

- `pre-commit` (ruff / autopep8 / codespell) ✅ · `mypy nicegui/run.py nicegui/native/native.py` ✅ · `pylint` 10.00 ✅
- `pytest tests/test_run.py` → 5 passed ✅
- Both import orders clean; `run.SPAWN_CONTEXT is native.SPAWN_CONTEXT` ✅
- Empirical: pool `_mp_context` `fork`→`spawn`; `cpu_bound` child forked→spawned.
</details>

<details>
<summary><b>Optional regression test (not added — kept the diff minimal)</b></summary>

Drop into `tests/test_run.py` if wanted:

```python
def test_cpu_bound_pool_uses_spawn_context():
    run.setup()
    assert run.process_pool is not None
    assert run.process_pool._mp_context.get_start_method() == 'spawn'  # pylint: disable=protected-access
    run.tear_down()
```
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary. <!-- regression test drafted above for optional adoption -->
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API; the Linux behavior change is described above.
