### PR TITLE
Harden X-Forwarded-Prefix reflection (brick: comment + defense-in-depth)

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -172,6 +172,9 @@ class Client:
                 background=BackgroundTask(self.delete),
             )
         self.outbox.updates.clear()
+        # `prefix` is reflected raw into the page (importmap, <script src>, JS `prefix:`, CSS @import) via `| safe`.
+        # It comes from the X-Forwarded-Prefix header: client-settable only on a directly-exposed app (then self-XSS,
+        # since a browser cannot send a victim's custom header cross-origin), or via a pass-through proxy / unkeyed cache.
         prefix = request.headers.get('X-Forwarded-Prefix', '') + request.scope.get('root_path', '')
         elements = json.dumps({
             id: element._to_dict() for id, element in self.elements.items()  # pylint: disable=protected-access

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+from urllib.parse import quote
 
 from fastapi import Request
 from fastapi.responses import Response
@@ -172,10 +173,12 @@ class Client:
                 background=BackgroundTask(self.delete),
             )
         self.outbox.updates.clear()
-        # `prefix` is reflected raw into the page (importmap, <script src>, JS `prefix:`, CSS @import) via `| safe`.
-        # It comes from the X-Forwarded-Prefix header: client-settable only on a directly-exposed app (then self-XSS,
-        # since a browser cannot send a victim's custom header cross-origin), or via a pass-through proxy / unkeyed cache.
-        prefix = request.headers.get('X-Forwarded-Prefix', '') + request.scope.get('root_path', '')
+        # Defense in depth: `prefix` is reflected into the page (importmap, <script src>, JS `prefix:`, CSS @import)
+        # via `| safe`, and the X-Forwarded-Prefix part is client-controllable on a directly-exposed app or a
+        # pass-through proxy. Percent-encode it so no structural char (`"` `'` `<` `>` `` ` `` `$` `\` space) can break
+        # out of any context. A legitimate mount prefix is a URL path, so `quote(safe='/%')` is a no-op for real
+        # deployments (`%` is kept safe to avoid double-encoding an already-encoded prefix).
+        prefix = quote(request.headers.get('X-Forwarded-Prefix', ''), safe='/%') + request.scope.get('root_path', '')
         elements = json.dumps({
             id: element._to_dict() for id, element in self.elements.items()  # pylint: disable=protected-access
         })

--- a/tests/test_forwarded_prefix.py
+++ b/tests/test_forwarded_prefix.py
@@ -1,0 +1,23 @@
+from nicegui import ui
+from nicegui.testing import User
+
+
+async def test_forwarded_prefix_injection_is_neutralized(user: User):
+    @ui.page('/')
+    def page():
+        ui.label('Hello')
+
+    payload = '"></script><script>PWNED</script>'
+    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': payload})
+    assert payload not in response.text, 'X-Forwarded-Prefix must not be reflected raw into the page'
+    assert '<script>PWNED' not in response.text, 'the injected tag must not survive in executable form'
+    assert '%3Cscript%3EPWNED' in response.text, 'dangerous characters should be percent-encoded'
+
+
+async def test_forwarded_prefix_normal_value_is_unchanged(user: User):
+    @ui.page('/')
+    def page():
+        ui.label('Hello')
+
+    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': '/myapp'})
+    assert '/myapp/_nicegui/' in response.text, 'a legitimate path prefix must pass through unchanged'


### PR DESCRIPTION
*Drafted with Claude Code, on a branch in my own fork — for review, not upstream.*

🧱 **Brick for review** (拋磚引玉) — two separable commits; feeling out the shape before deciding anything. Check out either commit to feel each independently.

## Motivation

`Client.build_response` reflects `prefix` into several `| safe` template sinks (importmap JSON, `js_imports`, the JS `prefix:` string, `<script src>`, CSS `@import`). `prefix` derives from the `X-Forwarded-Prefix` request header, which is client-influenceable on a directly-exposed app or a pass-through proxy. Element content is escaped via `HTML_ESCAPE_TABLE`; this header is not — a defense-in-depth gap (worst realistic vector: cache poisoning on an unkeyed header). Behind a proxy that sets/strips the header, it's inert.

## Implementation

- **Brick 1 (`80e75c10`)** — comment only: record *why* the `| safe` is bounded and where the value comes from. Zero behavior change.
- **Brick 2 (`2ea0a148`)** — `quote(prefix, safe='/%')` at the **source** (covers the `generate_resources` sinks too, not just the template) + `tests/test_forwarded_prefix.py`. A legitimate URL-path prefix is unchanged byte-for-byte; only structural chars (`" ' < > \ ` $` space) get percent-encoded. Internal-only → shippable in 3.x, no 4.0 wait.

## Progress

- [x] Empirically verified: raw injection reflections **13 → 0**; `/myapp` passthrough unchanged (resource URLs build correctly)
- [x] `pytest tests/test_forwarded_prefix.py` → 2 passed; pre-commit clean on changed files
- [ ] **Open choice points:** `quote()` vs entity-escape table · scope (also harden `middlewares.py` / `sub_pages_router.py` header reads?) · `root_path` left unquoted (trusted) · Brick 1 → code comment vs Security docs
- [ ] Not run: full suite / mypy / pylint
- [ ] Disclosure path TBD — kept understated since this fork is public
