### PR TITLE
Brick 1: comment the X-Forwarded-Prefix reflection (no behavior change)

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -10,6 +10,13 @@
     />
     <link href="{{ favicon_url }}" rel="shortcut icon" />
     <style>
+      {#
+        `prefix` is reflected below (and in <script src>, the JS `prefix:` string, and CSS @import) with `| safe`.
+        A scanner flagging this as XSS is seeing a bounded case: `prefix` is the X-Forwarded-Prefix request header
+        (+ root_path), client-settable only on a directly-exposed app — and then it's self-XSS, since a browser
+        cannot be made to send a victim's custom header cross-origin. It becomes victim-reachable only via a
+        pass-through proxy or an unkeyed shared cache.
+      #}
       @layer theme, base, quasar, nicegui, components, utilities, overrides, quasar_importants;
       @import url("{{ prefix | safe }}/_nicegui/{{version}}/static/fonts.css") layer(base);
       {% if prod_js %}


### PR DESCRIPTION
*Brick — drafted with Claude Code, in my fork for review.*

## Motivation
Record *why* `prefix` is emitted with `| safe` and where it comes from, so the bounded risk is legible to the next reader. Zero behavior change.

## Implementation
One comment above `prefix = …` in `client.py`: the value is reflected raw into importmap / `<script src>` / JS `prefix:` / CSS `@import`; it derives from `X-Forwarded-Prefix`; client-settable only on a directly-exposed app (then self-XSS — a browser can't send a victim's custom header cross-origin) or via a pass-through proxy / unkeyed cache.

## Progress
- [x] Comment only, no code change
- [ ] Decide: keep as code comment, or move/duplicate into the Security docs page (see the sibling doc PR)
