### PR TITLE
Brick 3: document that page responses must never be shared-cached

### DIFF
--- a/website/documentation/content/section_security.py
+++ b/website/documentation/content/section_security.py
@@ -186,6 +186,13 @@ doc.text('Client-Side Secrets', '''
     **To protect client sessions:**
 
     - **Serve pages over HTTPS** in production to prevent traffic sniffing.
+    - **Never let a shared cache store page responses.** Each page embeds a fresh `client_id`, so a CDN,
+      reverse-proxy cache, or any other intermediary that caches the HTML breaks the security model two ways:
+      it hands one visitor's session token to everyone who hits that cache entry, and it turns any reflected input
+      into a cache-poisoning vector — a single malicious request can store attacker-controlled HTML (XSS, phishing,
+      defacement) that is then served to every subsequent visitor. NiceGUI sends `Cache-Control: no-store` on pages
+      for exactly this reason — do not override or strip it (e.g. a blanket "cache everything" rule). This is the
+      shared-cache counterpart to the private browser-cache leak noted above.
     - **Do not serve untrusted content** from the same origin
       (e.g. serving user-uploaded HTML files could leak secrets via JavaScript).
     - **Do not expose `client_id`** in logs, URLs, or API responses visible to other users.


### PR DESCRIPTION
*Brick — drafted with Claude Code, in my fork for review.*

## Motivation
The Security → "Client-Side Secrets" section says each page embeds a fresh `client_id` and to guard against "browser cache exposure" — but that's the **private** browser cache. It never states the **shared/intermediary** cache invariant: a CDN or reverse-proxy cache that stores page HTML serves **one visitor's `client_id` to everyone** — session takeover, no XSS required. The framework enforces it (`Cache-Control: no-store` on pages, `client.py:170`/`218`) but the docs don't tell deployers the rationale or "don't override it". This is arguably the conceptual core of the caching misconception (and what makes the sibling XSS PR's cache-poisoning vector possible at all).

## Implementation
One bullet under "To protect client sessions:" — never let a shared cache store page responses; `no-store` is sent for this reason; don't strip it; distinguished from the private browser-cache leak already noted.

## Progress
- [x] Doc text only; pre-commit clean
- [ ] Wording/placement review — bullet vs its own short subsection?
- [ ] Cross-link from the sibling X-Forwarded-Prefix PR?
