### PR TITLE
Brick: document commonly-misreported (non-issue) patterns in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,18 @@ The latest version of NiceGUI is supported.
 You are encouraged to write tests for your application and update your NiceGUI version frequently after ensuring that your tests are passing.
 This way you will benefit from the latest features, bug fixes, and **security fixes**.
 
+## Commonly Misreported Patterns
+
+Automated scanners and AI-assisted reviews frequently flag the patterns below.
+They are **by design or already bounded**, so please trace the data flow and check them against this list before filing — it keeps the advisory queue focused on real issues.
+
+- **`| safe` in the page template** (`nicegui/templates/index.html`). Jinja auto-escaping is bypassed there intentionally; the values are escaped at the source instead (for example, element data is escaped with a table sized for the `String.raw` script context it lands in). A bare `| safe` is not itself a finding — trace where the value comes from and how it is escaped.
+- **Raw `innerHTML` in `ui.html` / `ui.markdown`** (`nicegui/elements/html.js`, `markdown.js`). The raw assignment is the `else` branch of `sanitize`: the opt-in `sanitize=False` path. The default (`sanitize=True`) sanitizes via DOMPurify. Passing untrusted input with `sanitize=False` is the caller's documented responsibility.
+- **`ui.add_head_html`, `ui.add_body_html`, `ui.run_javascript`, `ui.add_css`.** These inject raw HTML/JS/CSS by design and are documented as never-for-untrusted-input. Using them with unsanitized user data is an application bug, not a framework vulnerability.
+- **`ast.literal_eval` in the docs.** `literal_eval` only parses literals; it is the safe alternative to `eval` that the documentation demonstrates.
+
+If instead you have found a way **around** one of these protections — an escaping bypass, or a default `sanitize=True` path that still executes script — that is a real issue and we would very much like to hear about it. Please include a reproduction.
+
 ## Reporting a Vulnerability
 
 If you think you found a vulnerability, and even if you are not sure about it, please report it right away


### PR DESCRIPTION
*Brick — drafted with Claude Code, in my fork for review. Anti-bad-GHSA inoculation (not on #184).*

## Motivation
False-positive security reports cost maintainer time. The people who file them (and their LLMs) read `SECURITY.md` before the advisory form — not our code comments. So the highest-leverage shield is a "what looks unsafe but isn't" list *there*.

## Implementation
New **Commonly Misreported Patterns** section in `SECURITY.md`, right before "Reporting a Vulnerability". Lists, with the *why it's bounded* for each: the page-template `| safe` (escaped at source), the `sanitize=False` raw-`innerHTML` opt-out, the by-design raw HTML/JS/CSS helpers, and `literal_eval`. Crucially, it **invites** genuine bypass reports (an escaping bypass, or a default-`sanitize=True` path that still executes) so it doesn't chill real findings.

## Progress
- [x] Doc only; pre-commit (mdformat/codespell) clean
- [ ] Wording/policy is Zauberzeug's call — "we may close as non-issue" framing is deliberately measured
- [ ] Open: is a public "what's safe" list an acceptable mild attacker-roadmap trade? (Same trade the Security docs already make)
