### PR TITLE
Reject ui.sub_pages parameter names that are not valid identifiers

### DIFF
--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -197,10 +197,10 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
     @staticmethod
     def _validate_route(path: str) -> None:
         for parameter in re.findall(r'\{(.*?)\}', path):
-            if not re.fullmatch(r'\w+', parameter):
+            if not parameter.isidentifier():
                 raise ValueError(
                     f'Invalid route "{path}": the parameter "{{{parameter}}}" is not supported. '
-                    'ui.sub_pages only supports single-segment "{name}" parameters, '
+                    'ui.sub_pages only supports single-segment "{name}" parameters that are valid Python identifiers, '
                     'not Starlette-style converters like "{name:path}". '
                     'For wildcard routing, use show_404=False and read PageArguments.remaining_path '
                     '(see https://nicegui.io/documentation/sub_pages).'

--- a/tests/test_sub_pages_match_path.py
+++ b/tests/test_sub_pages_match_path.py
@@ -173,7 +173,9 @@ def test_validate_route_accepts_supported_patterns():
 
 def test_validate_route_rejects_unsupported_patterns():
     """Starlette-style converters and other non-{name} parameters are rejected at registration time."""
-    for pattern in ['/{_:path}', '/{name:path}', '/{id:int}', '/{}', '/item/{a-b}']:
+    # digit-leading names like {1a}/{2} are not valid regex group names and would otherwise crash _match_path at
+    # navigation time, so they must be rejected here at registration.
+    for pattern in ['/{_:path}', '/{name:path}', '/{id:int}', '/{}', '/item/{a-b}', '/{1a}', '/{2}', '/user/{1}']:
         with pytest.raises(ValueError, match='not supported'):
             ui.sub_pages._validate_route(pattern)
 


### PR DESCRIPTION
*Drafted by Claude Code on @evnchn's behalf.*

### Motivation

Fixes #191. `ui.sub_pages` route validation accepts digit-leading parameter names like `{1a}` / `{2}` at registration (`\w` allows a leading digit), but those are invalid Python regex group names — so the first navigation matching that prefix crashes with an uncaught `re.error: bad character in group name` from `_match_path`. PR #6092 added `_validate_route` to reject unsupported patterns at registration; this class slipped through.

### Implementation

Validate parameter names with `str.isidentifier()` instead of `re.fullmatch(r'\w+', ...)`. `isidentifier()` rejects digit-leading names (and `a-b`, `name:path`, empty) at registration with the existing helpful `ValueError`, while still accepting valid non-ASCII identifiers (`{café}`, `{π}`, `{变量}`) that match correctly today — which a `[A-Za-z_]\w*` regex would have wrongly rejected.

Added the digit-leading cases to `test_validate_route_rejects_unsupported_patterns`.

<details>
<summary>Verification</summary>

```
/u/{1a}  before: accepted by _validate_route, then re.error at match → after: rejected at registration
/u/{2}   same
/u/{name}, /u/{_x}, /u/{café}, /u/{π}, /u/{变量} → still accepted, match OK
```

Gates: `pre-commit` clean, `mypy ./nicegui` clean (243 files), `pylint nicegui/elements/sub_pages.py` 10.00/10, `pytest tests/test_sub_pages_match_path.py tests/test_sub_pages.py` 71/71. Independently confirmed (incl. the `isidentifier` vs regex unicode point) by a second reviewer (different model lineage).
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
