### PR TITLE
Don't swallow browser default for codemirror keybindings while disabled

### DIFF
--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -171,6 +171,8 @@ export default {
         linux, // unset linux will fall back to key
         win, // unset win will fall back to key
         run: () => {
+          // while disabled, don't fire or swallow the key: return false so the browser default and lower bindings run
+          if (this.disable) return false;
           this.$emit("keybinding", { key });
           return preventDefault;
         },

--- a/tests/test_codemirror_keybindings.py
+++ b/tests/test_codemirror_keybindings.py
@@ -21,6 +21,21 @@ def _press(screen: Screen, key: str, *, ctrl: bool = False) -> None:
     ''')
 
 
+def _press_default_prevented(screen: Screen, key: str, *, ctrl: bool = False) -> bool:
+    args = {
+        'key': key,
+        'code': f'Key{key.upper()}' if len(key) == 1 else key,
+        'ctrlKey': ctrl,
+        'bubbles': True,
+        'cancelable': True,
+    }
+    return screen.selenium.execute_script(f'''
+        const ev = new KeyboardEvent("keydown", {json.dumps(args)});
+        document.querySelector(".cm-content").dispatchEvent(ev);
+        return ev.defaultPrevented;
+    ''')
+
+
 def test_map_and_unmap_callbacks(screen: Screen):
     @ui.page('/')
     def page():
@@ -94,6 +109,27 @@ def test_keymap_does_not_fire_while_disabled(screen: Screen):
     screen.should_contain('enabled=True')
     _press(screen, 'x')
     screen.wait_for(lambda: events == ['fired while enabled'] * 2)
+
+
+def test_disabled_editor_does_not_swallow_keybinding(screen: Screen):
+    @ui.page('/')
+    def page():
+        editor = ui.codemirror('hello', keymap={
+            'Ctrl-b': ui.codemirror.KeyBinding(lambda: None, prevent_default=True),
+        })
+        ui.button('Disable', on_click=editor.disable)
+        ui.label().bind_text_from(editor, 'enabled', lambda value: f'enabled={value}')
+
+    screen.open('/')
+    screen.should_contain('hello')
+
+    # while enabled, prevent_default=True suppresses the browser default
+    assert _press_default_prevented(screen, 'b', ctrl=True) is True
+
+    screen.click('Disable')
+    screen.should_contain('enabled=False')
+    # while disabled, the keybinding must not swallow the key, so the browser default proceeds
+    assert _press_default_prevented(screen, 'b', ctrl=True) is False
 
 
 @pytest.mark.parametrize('keybinding, error', [


### PR DESCRIPTION
*Drafted by Claude Code on @evnchn's behalf.*

### Motivation

Fixes #193. A `ui.codemirror` keybinding with `prevent_default=True` still swallows the browser default and lower CodeMirror bindings while the editor is disabled, even though the Python callback correctly does not fire — contradicting the docstring "Keybindings do not fire while the editor is disabled." The client-side keymap handler runs unconditionally and returns `preventDefault`.

### Implementation

In `buildUserKeymap`'s `run`, short-circuit to `false` (key not handled) when the component's reactive `disable` prop is set, so the browser default and lower bindings proceed and the disabled editor is fully inert. Skips the emit too (the server already ignores it).

Added `test_disabled_editor_does_not_swallow_keybinding`: dispatches a synthetic `keydown` on `.cm-content` (same mechanism as the existing `_press` helper) and asserts `defaultPrevented` is `True` while enabled, `False` while disabled.

<details>
<summary>Verification (empirical, Playwright before/after)</summary>

Dispatching `Ctrl-b` (mapped with `prevent_default=True`) and reading `event.defaultPrevented`, enabled editor as control:

| | enabled (control) | disabled |
|---|---|---|
| **main (before)** | `True` | `True` — swallowed (bug) |
| **this PR** | `True` | `False` — fixed |

The enabled column staying `True` confirms the binding is genuinely active and the test measures the disabled-gating specifically. (The committed regression test is the Selenium `Screen` equivalent, run in CI; the table above is from a local Playwright run of the same dispatch.)
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
